### PR TITLE
Add timestamp logging, message filtering, and command presets

### DIFF
--- a/SerialTool/SerialTool.pro
+++ b/SerialTool/SerialTool.pro
@@ -64,6 +64,7 @@ SOURCES += \
     src/views/viewmanager.cpp \
     #src/views/scriptextension/scriptextensionview.cpp \
     src/views/texttr/textedit.cpp \
+    src/views/texttr/commandconfigdialog.cpp \
     src/views/texttr/texttrview.cpp \
     src/views/terminal/terminalview.cpp \
     src/views/terminal/qvterminal/qvtchar.cpp \
@@ -104,6 +105,7 @@ HEADERS  += \
     src/views/abstractview.h \
     #src/views/scriptextension/scriptextensionview.h \
     src/views/texttr/textedit.h \
+    src/views/texttr/commandconfigdialog.h \
     src/views/texttr/texttrview.h \
     src/views/terminal/terminalview.h \
     src/views/terminal/qvterminal/qvtchar.h \

--- a/SerialTool/resource/default.ini
+++ b/SerialTool/resource/default.ini
@@ -41,7 +41,9 @@ TransmitMode=Ascii
 RepeatInterval=1000
 ResendMode=false
 RxAreaWrapLine=false
+LogWithTimestamp=false
 HistoryBox\Items\size=0
+UserCommands\Items\size=0
 
 [Oscillograph]
 YOffset=0

--- a/SerialTool/src/views/texttr/commandconfigdialog.cpp
+++ b/SerialTool/src/views/texttr/commandconfigdialog.cpp
@@ -1,0 +1,97 @@
+#include "commandconfigdialog.h"
+
+#include <QAbstractItemView>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Command Presets"));
+    setModal(true);
+    resize(360, 320);
+
+    auto *mainLayout = new QVBoxLayout(this);
+
+    m_listWidget = new QListWidget(this);
+    m_listWidget->addItems(commands);
+    m_listWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
+    mainLayout->addWidget(m_listWidget);
+
+    auto *inputLayout = new QHBoxLayout();
+    m_inputEdit = new QLineEdit(this);
+    m_inputEdit->setPlaceholderText(tr("New command"));
+    inputLayout->addWidget(m_inputEdit);
+
+    m_addButton = new QPushButton(tr("Add"), this);
+    inputLayout->addWidget(m_addButton);
+    mainLayout->addLayout(inputLayout);
+
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    m_removeButton = new QPushButton(tr("Remove"), this);
+    buttonBox->addButton(m_removeButton, QDialogButtonBox::ActionRole);
+    mainLayout->addWidget(buttonBox);
+
+    connect(m_addButton, &QPushButton::clicked, this, &CommandConfigDialog::addCommand);
+    connect(m_removeButton, &QPushButton::clicked, this, &CommandConfigDialog::removeSelected);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &CommandConfigDialog::accept);
+    connect(m_listWidget, &QListWidget::itemSelectionChanged, this, &CommandConfigDialog::updateButtonStates);
+    connect(m_inputEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::updateButtonStates);
+
+    updateButtonStates();
+}
+
+QStringList CommandConfigDialog::commands() const
+{
+    QStringList result;
+    result.reserve(m_listWidget->count());
+    for (int i = 0; i < m_listWidget->count(); ++i) {
+        result.append(m_listWidget->item(i)->text());
+    }
+    return result;
+}
+
+void CommandConfigDialog::addCommand()
+{
+    const QString text = m_inputEdit->text().trimmed();
+    if (!canAdd(text)) {
+        return;
+    }
+    m_listWidget->addItem(text);
+    m_inputEdit->clear();
+    updateButtonStates();
+}
+
+void CommandConfigDialog::removeSelected()
+{
+    const auto selected = m_listWidget->selectedItems();
+    for (QListWidgetItem *item : selected) {
+        delete item;
+    }
+    updateButtonStates();
+}
+
+void CommandConfigDialog::updateButtonStates()
+{
+    const QString text = m_inputEdit->text().trimmed();
+    m_addButton->setEnabled(canAdd(text));
+    m_removeButton->setEnabled(!m_listWidget->selectedItems().isEmpty());
+}
+
+bool CommandConfigDialog::canAdd(const QString &text) const
+{
+    if (text.isEmpty()) {
+        return false;
+    }
+    for (int i = 0; i < m_listWidget->count(); ++i) {
+        if (m_listWidget->item(i)->text() == text) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/SerialTool/src/views/texttr/commandconfigdialog.h
+++ b/SerialTool/src/views/texttr/commandconfigdialog.h
@@ -1,0 +1,35 @@
+#ifndef COMMANDCONFIGDIALOG_H
+#define COMMANDCONFIGDIALOG_H
+
+#include <QDialog>
+
+class QListWidget;
+class QLineEdit;
+class QPushButton;
+
+class CommandConfigDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CommandConfigDialog(const QStringList &commands, QWidget *parent = nullptr);
+
+    QStringList commands() const;
+
+private slots:
+    void addCommand();
+    void removeSelected();
+    void updateButtonStates();
+
+private:
+    bool canAdd(const QString &text) const;
+
+private:
+    QListWidget *m_listWidget;
+    QLineEdit *m_inputEdit;
+    QPushButton *m_addButton;
+    QPushButton *m_removeButton;
+};
+
+#endif // COMMANDCONFIGDIALOG_H
+

--- a/SerialTool/src/views/texttr/texttrview.cpp
+++ b/SerialTool/src/views/texttr/texttrview.cpp
@@ -1,10 +1,23 @@
 #include "texttrview.h"
 #include "ui_texttrview.h"
-#include <QSettings>
-#include <QTextCodec>
-#include <QTimer>
-#include <QKeyEvent>
+#include "commandconfigdialog.h"
+#include <QCheckBox>
 #include <QDateTime>
+#include <QFile>
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QRadioButton>
+#include <QScrollBar>
+#include <QSettings>
+#include <QSignalBlocker>
+#include <QStandardItem>
+#include <QStandardItemModel>
+#include <QTextCodec>
+#include <QTextDocument>
+#include <QTextCursor>
+#include <QTimer>
+#include <QToolButton>
 
 TextTRView::TextTRView(QWidget *parent) :
     AbstractView(parent),
@@ -26,7 +39,16 @@ TextTRView::TextTRView(QWidget *parent) :
     QObject::connect(m_resendTimer, &QTimer::timeout, this, &TextTRView::sendData);
     connect(ui->resendIntervalBox, SIGNAL(valueChanged(int)), this, SLOT(setResendInterval(int)));
     connect(ui->historyBox, SIGNAL(activated(const QString &)), this, SLOT(onHistoryBoxChanged(const QString &)));
-    connect(ui->wrapLineBox, SIGNAL(stateChanged(int)), this, SLOT(onWrapBoxChanged(int)));
+    connect(ui->filterLineEdit, &QLineEdit::textChanged, this, &TextTRView::onFilterTextChanged);
+    connect(ui->clearFilterButton, &QToolButton::clicked, this, &TextTRView::onClearFilterClicked);
+    connect(ui->searchLineEdit, &QLineEdit::returnPressed, this, &TextTRView::onSearchReturnPressed);
+    connect(ui->searchNextButton, &QPushButton::clicked, this, [this]() { findInReceive(true); });
+    connect(ui->searchPrevButton, &QPushButton::clicked, this, [this]() { findInReceive(false); });
+    connect(ui->logTimestampBox, &QCheckBox::toggled, this, &TextTRView::onLogTimestampToggled);
+    connect(ui->saveCommandButton, &QPushButton::clicked, this, &TextTRView::onSaveCommandClicked);
+    connect(ui->manageCommandsButton, &QPushButton::clicked, this, &TextTRView::onManageCommandsClicked);
+
+    refreshCommandBox();
 }
 
 TextTRView::~TextTRView()
@@ -77,10 +99,19 @@ void TextTRView::loadConfig(QSettings *config)
     ui->wrapLineBox->setChecked(status);
     ui->textEditRx->setWrap(status);
 
-    // load history
+    m_logWithTimestamp = config->value("LogWithTimestamp").toBool();
+    {
+        QSignalBlocker blocker(ui->logTimestampBox);
+        ui->logTimestampBox->setChecked(m_logWithTimestamp);
+    }
+
+    // load history & user commands
     loadHistory(config);
+    loadUserCommands(config);
 
     config->endGroup();
+
+    refreshCommandBox();
 }
 
 void TextTRView::saveConfig(QSettings *config)
@@ -99,9 +130,11 @@ void TextTRView::saveConfig(QSettings *config)
     config->setValue("ResendMode", QVariant(ui->resendBox->isChecked()));
     // save warp line
     config->setValue("RxAreaWrapLine", QVariant(ui->wrapLineBox->isChecked()));
+    config->setValue("LogWithTimestamp", QVariant(ui->logTimestampBox->isChecked()));
 
     // save history
     saveHistory(config);
+    saveUserCommands(config);
 
     config->endGroup();
 }
@@ -123,32 +156,61 @@ void TextTRView::loadSettings(QSettings *config)
     setTabWidth(config->value("TerminalTabWidth").toInt());
     setAutoIndent(config->value("TerminalAutoIndent").toBool());
     setIndentationGuides(config->value("TerminalIndentationGuides").toBool());
-    m_timeStamp = config->value("TerminalUseTimeStamp").toBool();
-    m_frameSeparator = config->value("TerminalFrameSeparator").toString();
-    m_timeStampFormat = config->value("TerminalTimeStampFormat").toString();
+    m_timeStampFormat = config->value("TerminalTimeStampFormat", "yyyy-MM-dd HH:mm:ss").toString();
+    if (m_timeStampFormat.isEmpty()) {
+        m_timeStampFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+    }
+    rebuildReceiveView();
 }
 
 void TextTRView::loadHistory(QSettings *config)
 {
+    m_historyRecords.clear();
     config->beginGroup("HistoryBox");
     int count = config->beginReadArray("Items");
     for (int i = 0; i < count; ++i) {
         config->setArrayIndex(i);
-        ui->historyBox->addItem(config->value("data").toString());
+        m_historyRecords.append(config->value("data").toString());
     }
     config->endArray();
-    ui->historyBox->setCurrentIndex(0);
     config->endGroup();
 }
 
 void TextTRView::saveHistory(QSettings *config)
 {
     config->beginGroup("HistoryBox");
-    int count = ui->historyBox->count();
     config->beginWriteArray("Items");
+    for (int i = 0; i < m_historyRecords.size(); ++i) {
+        config->setArrayIndex(i);
+        config->setValue("data", m_historyRecords.at(i));
+    }
+    config->endArray();
+    config->endGroup();
+}
+
+void TextTRView::loadUserCommands(QSettings *config)
+{
+    m_userCommands.clear();
+    config->beginGroup("UserCommands");
+    int count = config->beginReadArray("Items");
     for (int i = 0; i < count; ++i) {
         config->setArrayIndex(i);
-        config->setValue("data", ui->historyBox->itemText(i));
+        const QString value = config->value("data").toString();
+        if (!value.isEmpty()) {
+            m_userCommands.append(value);
+        }
+    }
+    config->endArray();
+    config->endGroup();
+}
+
+void TextTRView::saveUserCommands(QSettings *config)
+{
+    config->beginGroup("UserCommands");
+    config->beginWriteArray("Items");
+    for (int i = 0; i < m_userCommands.size(); ++i) {
+        config->setArrayIndex(i);
+        config->setValue("data", m_userCommands.at(i));
     }
     config->endArray();
     config->endGroup();
@@ -159,6 +221,117 @@ void TextTRView::setHighlight(const QString &language)
     // Send and Receive area highlight.
     ui->textEditTx->setHighLight(language);
     ui->textEditRx->setHighLight(language);
+}
+
+void TextTRView::refreshCommandBox()
+{
+    QSignalBlocker blocker(ui->historyBox);
+    auto *model = qobject_cast<QStandardItemModel *>(ui->historyBox->model());
+    if (!model) {
+        model = new QStandardItemModel(ui->historyBox);
+        ui->historyBox->setModel(model);
+    }
+    model->clear();
+
+    for (const QString &command : m_userCommands) {
+        auto *item = new QStandardItem(command);
+        model->appendRow(item);
+    }
+
+    if (!m_userCommands.isEmpty() && !m_historyRecords.isEmpty()) {
+        auto *separator = new QStandardItem(QStringLiteral("──────────"));
+        separator->setFlags(Qt::NoItemFlags);
+        model->appendRow(separator);
+    }
+
+    for (const QString &history : m_historyRecords) {
+        auto *item = new QStandardItem(history);
+        model->appendRow(item);
+    }
+
+    ui->historyBox->setCurrentIndex(-1);
+}
+
+void TextTRView::rememberHistory(const QString &command)
+{
+    if (command.isEmpty()) {
+        return;
+    }
+    m_historyRecords.removeAll(command);
+    m_historyRecords.prepend(command);
+    const int kMaxHistory = 20;
+    while (m_historyRecords.size() > kMaxHistory) {
+        m_historyRecords.removeLast();
+    }
+    refreshCommandBox();
+}
+
+void TextTRView::appendReceivedEntry(const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+    QString entry = text;
+    if (!entry.endsWith('\n')) {
+        entry.append('\n');
+    }
+    m_receivedTexts.append(entry);
+    m_entryTimestamps.append(QDateTime::currentDateTime());
+    rebuildReceiveView();
+}
+
+void TextTRView::rebuildReceiveView()
+{
+    if (!ui) {
+        return;
+    }
+    const QString filter = ui->filterLineEdit->text();
+    const bool atBottom = ui->textEditRx->verticalScrollBar()->value() ==
+            ui->textEditRx->verticalScrollBar()->maximum();
+
+    QString buffer;
+    buffer.reserve(m_receivedTexts.size() * 32);
+    for (int i = 0; i < m_receivedTexts.size(); ++i) {
+        const QString &raw = m_receivedTexts.at(i);
+        if (!filter.isEmpty() && !raw.contains(filter, Qt::CaseInsensitive)) {
+            continue;
+        }
+        buffer.append(formatEntry(m_entryTimestamps.at(i), raw));
+    }
+
+    ui->textEditRx->setPlainText(buffer);
+    if (atBottom) {
+        QTextCursor cursor = ui->textEditRx->textCursor();
+        cursor.movePosition(QTextCursor::End);
+        ui->textEditRx->setTextCursor(cursor);
+        ui->textEditRx->verticalScrollBar()->setValue(ui->textEditRx->verticalScrollBar()->maximum());
+    }
+}
+
+QString TextTRView::formatEntry(const QDateTime &timestamp, const QString &text) const
+{
+    if (!m_logWithTimestamp) {
+        return text;
+    }
+    return QStringLiteral("[%1] %2").arg(timestamp.toString(m_timeStampFormat), text);
+}
+
+void TextTRView::findInReceive(bool forward)
+{
+    const QString keyword = ui->searchLineEdit->text();
+    if (keyword.isEmpty()) {
+        return;
+    }
+    QTextDocument::FindFlags flags;
+    if (!forward) {
+        flags |= QTextDocument::FindBackward;
+    }
+    if (!ui->textEditRx->find(keyword, flags)) {
+        QTextCursor cursor = ui->textEditRx->textCursor();
+        cursor.movePosition(forward ? QTextCursor::Start : QTextCursor::End);
+        ui->textEditRx->setTextCursor(cursor);
+        ui->textEditRx->find(keyword, flags);
+    }
 }
 
 void TextTRView::receiveData(const QByteArray &array)
@@ -177,11 +350,7 @@ void TextTRView::receiveData(const QByteArray &array)
         }
         arrayToHex(string, array, 16);
     }
-    if (m_timeStamp) {
-        appendTimeStamp(string);
-    } else {
-        ui->textEditRx->append(pre + string);
-    }
+    appendReceivedEntry(pre + string);
 }
 
 void TextTRView::clear()
@@ -189,6 +358,9 @@ void TextTRView::clear()
     ui->textEditRx->clear();
     m_asciiBuf->clear();
     m_hexCount = 0;
+    m_receivedTexts.clear();
+    m_entryTimestamps.clear();
+    rebuildReceiveView();
 }
 
 void TextTRView::setFontFamily(QString fontFamily, int size, QString style)
@@ -237,18 +409,7 @@ void TextTRView::onSendButtonClicked()
     QString str = ui->textEditTx->toPlainText();
     if (!str.isEmpty()) {
         sendData();
-
-        // 历史记录下拉列表删除多余项
-        while (ui->historyBox->count() >= 20) {
-            ui->historyBox->removeItem(19);
-        }
-        // 数据写入历史记录下拉列表
-        int i = ui->historyBox->findText(str);
-        if (i != -1) { // 存在的项先删除
-            ui->historyBox->removeItem(i);
-        }
-        ui->historyBox->insertItem(0, str); // 数据添加到第0个元素
-        ui->historyBox->setCurrentIndex(0);
+        rememberHistory(str);
     }
 }
 
@@ -293,6 +454,48 @@ void TextTRView::setTextCodec(const QString &name)
 void TextTRView::onHistoryBoxChanged(const QString &string)
 {
     ui->textEditTx->setPlainText(string);
+}
+
+void TextTRView::onFilterTextChanged(const QString &)
+{
+    rebuildReceiveView();
+}
+
+void TextTRView::onClearFilterClicked()
+{
+    ui->filterLineEdit->clear();
+}
+
+void TextTRView::onSearchReturnPressed()
+{
+    findInReceive(true);
+}
+
+void TextTRView::onLogTimestampToggled(bool enabled)
+{
+    m_logWithTimestamp = enabled;
+    rebuildReceiveView();
+}
+
+void TextTRView::onSaveCommandClicked()
+{
+    const QString command = ui->textEditTx->toPlainText().trimmed();
+    if (command.isEmpty()) {
+        return;
+    }
+    if (!m_userCommands.contains(command)) {
+        m_userCommands.prepend(command);
+        refreshCommandBox();
+    }
+}
+
+void TextTRView::onManageCommandsClicked()
+{
+    CommandConfigDialog dialog(m_userCommands, this);
+    if (dialog.exec() == QDialog::Accepted) {
+        m_userCommands = dialog.commands();
+        refreshCommandBox();
+    }
 }
 
 void TextTRView::arrayToHex(QString &str, const QByteArray &array, int countOfLine)
@@ -422,28 +625,6 @@ void TextTRView::arrayToString(QString &str, const QByteArray &array)
     default: // ASCII
         arrayToASCII(str, array);
         break;
-    }
-}
-
-void TextTRView::appendTimeStamp(const QString &string)
-{
-    QRegularExpression re(".+?(" + m_frameSeparator + "|$)");
-    QRegularExpressionMatch match = re.match(string);
-    QRegularExpressionMatchIterator it = re.globalMatch(string);
-    QString curTime = QDateTime::currentDateTime()
-            .toString(m_timeStampFormat);
-    while (it.hasNext()) {
-        QString span = it.next().captured(0);
-        if (m_nextFrame) {
-            ui->textEditRx->append(curTime);
-        }
-        m_nextFrame = span.indexOf(
-                    QRegularExpression(m_frameSeparator + "$")) != -1;
-        if (m_nextFrame) {
-            span.chop(m_frameSeparator.length());
-            span.append('\n');
-        }
-        ui->textEditRx->append(span);
     }
 }
 

--- a/SerialTool/src/views/texttr/texttrview.h
+++ b/SerialTool/src/views/texttr/texttrview.h
@@ -3,6 +3,11 @@
 
 #include "../abstractview.h"
 
+#include <QByteArray>
+#include <QDateTime>
+#include <QStringList>
+#include <QVector>
+
 namespace Ui {
 class TextTRView;
 }
@@ -39,6 +44,15 @@ private:
     void setIndentationGuides(bool enable);
     void saveText(const QString &fname);
 
+    void appendReceivedEntry(const QString &text);
+    void rebuildReceiveView();
+    QString formatEntry(const QDateTime &timestamp, const QString &text) const;
+    void refreshCommandBox();
+    void loadUserCommands(QSettings *config);
+    void saveUserCommands(QSettings *config);
+    void rememberHistory(const QString &command);
+    void findInReceive(bool forward);
+
     void keyPressEvent(QKeyEvent  *event);
     void arrayToHex(QString &str, const QByteArray &arr, int countOfLine);
     void arrayToString(QString &str, const QByteArray &arr);
@@ -50,8 +64,6 @@ private:
     void arrayToDualByte(QString &str, const QByteArray &array);
     void arrayToASCII(QString &str, const QByteArray &array);
 
-    void appendTimeStamp(const QString &string);
-
 private slots:
     void sendData();
     void onWrapBoxChanged(int status);
@@ -59,6 +71,12 @@ private slots:
     void updateResendTimerStatus();
     void setResendInterval(int msc);
     void onHistoryBoxChanged(const QString &string);
+    void onFilterTextChanged(const QString &text);
+    void onClearFilterClicked();
+    void onSearchReturnPressed();
+    void onLogTimestampToggled(bool enabled);
+    void onSaveCommandClicked();
+    void onManageCommandsClicked();
 
 private:
     enum TextCodec {
@@ -75,8 +93,12 @@ private:
     QByteArray *m_asciiBuf;
     enum TextCodec m_textCodec;
     QByteArray m_codecName;
-    bool m_nextFrame = true, m_timeStamp = false;
-    QString m_timeStampFormat, m_frameSeparator;
+    bool m_logWithTimestamp = false;
+    QString m_timeStampFormat;
+    QVector<QDateTime> m_entryTimestamps;
+    QStringList m_receivedTexts;
+    QStringList m_historyRecords;
+    QStringList m_userCommands;
 };
 
 #endif // TEXTTRVIEW_H

--- a/SerialTool/ui/texttrview.ui
+++ b/SerialTool/ui/texttrview.ui
@@ -28,16 +28,82 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="TextEdit" name="textEditRx" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-        <horstretch>0</horstretch>
-        <verstretch>1</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="focusPolicy">
-       <enum>Qt::ClickFocus</enum>
-      </property>
+     <widget class="QWidget" name="rxContainer" native="true">
+      <layout class="QVBoxLayout" name="verticalLayout_rx">
+       <property name="spacing">
+        <number>4</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_filter">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="filterLineEdit">
+           <property name="placeholderText">
+            <string>Filter…</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="clearFilterButton">
+           <property name="text">
+            <string>✕</string>
+           </property>
+           <property name="toolTip">
+            <string>Clear filter</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="searchLineEdit">
+           <property name="placeholderText">
+            <string>Search…</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="searchPrevButton">
+           <property name="text">
+            <string>Prev</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="searchNextButton">
+           <property name="text">
+            <string>Next</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="TextEdit" name="textEditRx" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>1</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="focusPolicy">
+          <enum>Qt::ClickFocus</enum>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="layoutWidget_5">
       <layout class="QHBoxLayout" name="horizontalLayout_19">
@@ -117,6 +183,13 @@
                </property>
                <property name="text">
                 <string>Wrap Line</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="logTimestampBox">
+               <property name="text">
+                <string>Show Timestamp</string>
                </property>
               </widget>
              </item>
@@ -213,6 +286,30 @@
          <property name="verticalSpacing">
           <number>3</number>
          </property>
+         <item row="1" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="commandLayout">
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <item>
+            <widget class="QComboBox" name="historyBox"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="saveCommandButton">
+             <property name="text">
+              <string>Save Command</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="manageCommandsButton">
+             <property name="text">
+              <string>Manage…</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
          <item row="2" column="1">
           <widget class="QPushButton" name="sendButton">
            <property name="enabled">
@@ -228,9 +325,6 @@
             <string>Send</string>
            </property>
           </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QComboBox" name="historyBox"/>
          </item>
          <item row="0" column="0" colspan="2">
           <widget class="TextEdit" name="textEditTx" native="true">
@@ -263,11 +357,14 @@
  </customwidgets>
  <tabstops>
   <tabstop>textEditTx</tabstop>
-  <tabstop>sendButton</tabstop>
   <tabstop>historyBox</tabstop>
+  <tabstop>saveCommandButton</tabstop>
+  <tabstop>manageCommandsButton</tabstop>
+  <tabstop>sendButton</tabstop>
   <tabstop>portReadAscii</tabstop>
   <tabstop>portReadHex</tabstop>
   <tabstop>wrapLineBox</tabstop>
+  <tabstop>logTimestampBox</tabstop>
   <tabstop>portWriteAscii</tabstop>
   <tabstop>portWriteHex</tabstop>
   <tabstop>resendBox</tabstop>


### PR DESCRIPTION
## Summary
- add a timestamp toggle and new receive pane toolbar for filtering and searching incoming messages
- persist received data so filters and timestamp formatting can be applied on demand and expose controls to manage saved commands
- add a command presets dialog and configuration persistence for user-defined instructions

## Testing
- not run (Qt tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ec590638108323ac909982bb146a15