### PR TITLE
Add terminal logging, filtering, and command management options

### DIFF
--- a/SerialTool/SerialTool.pro
+++ b/SerialTool/SerialTool.pro
@@ -65,6 +65,7 @@ SOURCES += \
     #src/views/scriptextension/scriptextensionview.cpp \
     src/views/texttr/textedit.cpp \
     src/views/texttr/texttrview.cpp \
+    src/views/texttr/commandconfigdialog.cpp \
     src/views/terminal/terminalview.cpp \
     src/views/terminal/qvterminal/qvtchar.cpp \
     src/views/terminal/qvterminal/qvtcharformat.cpp \
@@ -105,6 +106,7 @@ HEADERS  += \
     #src/views/scriptextension/scriptextensionview.h \
     src/views/texttr/textedit.h \
     src/views/texttr/texttrview.h \
+    src/views/texttr/commandconfigdialog.h \
     src/views/terminal/terminalview.h \
     src/views/terminal/qvterminal/qvtchar.h \
     src/views/terminal/qvterminal/qvtcharformat.h \

--- a/SerialTool/resource/default.ini
+++ b/SerialTool/resource/default.ini
@@ -8,6 +8,7 @@ TerminalIndentationGuides=false
 TerminalTabsInsertSpaces=false
 TerminalAutoIndent=true
 TerminalTabWidth=4
+TerminalLogTimeFormat=yyyy-MM-dd HH:mm:ss
 PlotBackground=#053846
 AxisColor=#9499a3
 UpdateInterval=25
@@ -41,7 +42,9 @@ TransmitMode=Ascii
 RepeatInterval=1000
 ResendMode=false
 RxAreaWrapLine=false
+LogFormatEnabled=false
 HistoryBox\Items\size=0
+UserCommands\Items\size=0
 
 [Oscillograph]
 YOffset=0

--- a/SerialTool/src/views/texttr/commandconfigdialog.cpp
+++ b/SerialTool/src/views/texttr/commandconfigdialog.cpp
@@ -1,0 +1,136 @@
+#include "commandconfigdialog.h"
+
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QListWidget>
+#include <QPushButton>
+#include <QVBoxLayout>
+
+CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("User Commands"));
+    setModal(true);
+
+    m_listWidget = new QListWidget(this);
+    m_listWidget->addItems(commands);
+    if (!commands.isEmpty()) {
+        m_listWidget->setCurrentRow(0);
+    }
+
+    m_input = new QLineEdit(this);
+    m_input->setPlaceholderText(tr("New command"));
+
+    m_addButton = new QPushButton(tr("Add"), this);
+    m_removeButton = new QPushButton(tr("Remove"), this);
+
+    QHBoxLayout *inputLayout = new QHBoxLayout;
+    inputLayout->addWidget(m_input);
+    inputLayout->addWidget(m_addButton);
+
+    QHBoxLayout *actionsLayout = new QHBoxLayout;
+    actionsLayout->addStretch();
+    actionsLayout->addWidget(m_removeButton);
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(
+        QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout;
+    mainLayout->addWidget(new QLabel(tr("Saved commands:"), this));
+    mainLayout->addWidget(m_listWidget);
+    mainLayout->addLayout(inputLayout);
+    mainLayout->addLayout(actionsLayout);
+    mainLayout->addWidget(buttonBox);
+
+    setLayout(mainLayout);
+
+    connect(m_addButton, &QPushButton::clicked,
+            this, &CommandConfigDialog::onAddCommand);
+    connect(m_removeButton, &QPushButton::clicked,
+            this, &CommandConfigDialog::onRemoveCommand);
+    connect(m_listWidget, &QListWidget::currentRowChanged,
+            this, &CommandConfigDialog::onSelectionChanged);
+    connect(m_listWidget, &QListWidget::itemSelectionChanged,
+            this, &CommandConfigDialog::onSelectionChanged);
+    connect(m_input, &QLineEdit::textChanged,
+            this, &CommandConfigDialog::onInputChanged);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &CommandConfigDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &CommandConfigDialog::reject);
+
+    updateButtons();
+}
+
+QStringList CommandConfigDialog::commands() const
+{
+    QStringList result;
+    for (int i = 0; i < m_listWidget->count(); ++i) {
+        result.append(m_listWidget->item(i)->text());
+    }
+    return result;
+}
+
+void CommandConfigDialog::setPendingCommand(const QString &command)
+{
+    QString trimmed = command.trimmed();
+    if (trimmed.isEmpty()) {
+        return;
+    }
+    m_input->setText(trimmed);
+    m_input->selectAll();
+    m_input->setFocus();
+}
+
+void CommandConfigDialog::onAddCommand()
+{
+    QString text = m_input->text().trimmed();
+    if (text.isEmpty()) {
+        return;
+    }
+
+    bool exists = false;
+    for (int i = 0; i < m_listWidget->count(); ++i) {
+        if (m_listWidget->item(i)->text() == text) {
+            exists = true;
+            m_listWidget->setCurrentRow(i);
+            break;
+        }
+    }
+
+    if (!exists) {
+        m_listWidget->addItem(text);
+        m_listWidget->setCurrentRow(m_listWidget->count() - 1);
+    }
+
+    m_input->clear();
+    updateButtons();
+}
+
+void CommandConfigDialog::onRemoveCommand()
+{
+    int row = m_listWidget->currentRow();
+    if (row >= 0) {
+        delete m_listWidget->takeItem(row);
+    }
+    updateButtons();
+}
+
+void CommandConfigDialog::onSelectionChanged()
+{
+    updateButtons();
+}
+
+void CommandConfigDialog::onInputChanged(const QString &text)
+{
+    Q_UNUSED(text)
+    updateButtons();
+}
+
+void CommandConfigDialog::updateButtons()
+{
+    const bool hasSelection = m_listWidget->currentRow() >= 0;
+    const bool hasText = !m_input->text().trimmed().isEmpty();
+    m_addButton->setEnabled(hasText);
+    m_removeButton->setEnabled(hasSelection);
+}

--- a/SerialTool/src/views/texttr/commandconfigdialog.h
+++ b/SerialTool/src/views/texttr/commandconfigdialog.h
@@ -1,0 +1,36 @@
+#ifndef COMMANDCONFIGDIALOG_H
+#define COMMANDCONFIGDIALOG_H
+
+#include <QDialog>
+#include <QStringList>
+
+class QListWidget;
+class QLineEdit;
+class QPushButton;
+
+class CommandConfigDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CommandConfigDialog(const QStringList &commands, QWidget *parent = nullptr);
+
+    QStringList commands() const;
+    void setPendingCommand(const QString &command);
+
+private slots:
+    void onAddCommand();
+    void onRemoveCommand();
+    void onSelectionChanged();
+    void onInputChanged(const QString &text);
+
+private:
+    void updateButtons();
+
+    QListWidget *m_listWidget;
+    QLineEdit *m_input;
+    QPushButton *m_addButton;
+    QPushButton *m_removeButton;
+};
+
+#endif // COMMANDCONFIGDIALOG_H

--- a/SerialTool/src/views/texttr/texttrview.cpp
+++ b/SerialTool/src/views/texttr/texttrview.cpp
@@ -1,10 +1,15 @@
 #include "texttrview.h"
 #include "ui_texttrview.h"
+#include "commandconfigdialog.h"
+#include <QComboBox>
+#include <QDateTime>
+#include <QKeyEvent>
+#include <QMessageBox>
 #include <QSettings>
 #include <QTextCodec>
+#include <QTextCursor>
+#include <QTextDocument>
 #include <QTimer>
-#include <QKeyEvent>
-#include <QDateTime>
 
 TextTRView::TextTRView(QWidget *parent) :
     AbstractView(parent),
@@ -17,16 +22,29 @@ TextTRView::TextTRView(QWidget *parent) :
 
     ui->textEditRx->setReadOnly(true);
     ui->textEditTx->setWrap(true); // Send area auto wrap.
+    ui->showTxBox->setEnabled(false);
+    ui->commandBox->setEnabled(false);
 
     setTextCodec("GB-2312"); // default
 
     connect(ui->wrapLineBox, SIGNAL(stateChanged(int)), this, SLOT(onWrapBoxChanged(int)));
     connect(ui->sendButton, &QPushButton::clicked, this, &TextTRView::onSendButtonClicked);
     connect(ui->resendBox, &QCheckBox::stateChanged, this, &TextTRView::updateResendTimerStatus);
-    QObject::connect(m_resendTimer, &QTimer::timeout, this, &TextTRView::sendData);
+    connect(m_resendTimer, &QTimer::timeout, this, &TextTRView::sendData);
     connect(ui->resendIntervalBox, SIGNAL(valueChanged(int)), this, SLOT(setResendInterval(int)));
     connect(ui->historyBox, SIGNAL(activated(const QString &)), this, SLOT(onHistoryBoxChanged(const QString &)));
-    connect(ui->wrapLineBox, SIGNAL(stateChanged(int)), this, SLOT(onWrapBoxChanged(int)));
+    connect(ui->logFormatBox, &QCheckBox::toggled, this, &TextTRView::onLogFormatBoxToggled);
+    connect(ui->filterEdit, &QLineEdit::textChanged, this, &TextTRView::onFilterTextChanged);
+    connect(ui->clearFilterButton, &QPushButton::clicked, this, &TextTRView::onClearFilterButtonClicked);
+    connect(ui->showRxBox, &QCheckBox::toggled, this, &TextTRView::onShowRxBoxToggled);
+    connect(ui->showTxBox, &QCheckBox::toggled, this, &TextTRView::onShowTxBoxToggled);
+    connect(ui->findNextButton, &QPushButton::clicked, this, &TextTRView::onFindNext);
+    connect(ui->findPrevButton, &QPushButton::clicked, this, &TextTRView::onFindPrevious);
+    connect(ui->searchEdit, &QLineEdit::returnPressed, this, &TextTRView::onSearchReturnPressed);
+    connect(ui->commandBox, QOverload<int>::of(&QComboBox::activated),
+            this, &TextTRView::onCommandBoxActivated);
+    connect(ui->saveCommandButton, &QPushButton::clicked, this, &TextTRView::onSaveCommandClicked);
+    connect(ui->manageCommandsButton, &QPushButton::clicked, this, &TextTRView::onManageCommandsClicked);
 }
 
 TextTRView::~TextTRView()
@@ -77,8 +95,19 @@ void TextTRView::loadConfig(QSettings *config)
     ui->wrapLineBox->setChecked(status);
     ui->textEditRx->setWrap(status);
 
+    // log format
+    ui->logFormatBox->setChecked(config->value("LogFormatEnabled").toBool());
+    onLogFormatBoxToggled(ui->logFormatBox->isChecked());
+
     // load history
+    ui->historyBox->clear();
     loadHistory(config);
+
+    // load user commands
+    loadUserCommands(config);
+
+    m_showRxMessages = ui->showRxBox->isChecked();
+    m_showTxMessages = ui->showTxBox->isChecked();
 
     config->endGroup();
 }
@@ -99,9 +128,13 @@ void TextTRView::saveConfig(QSettings *config)
     config->setValue("ResendMode", QVariant(ui->resendBox->isChecked()));
     // save warp line
     config->setValue("RxAreaWrapLine", QVariant(ui->wrapLineBox->isChecked()));
+    config->setValue("LogFormatEnabled", QVariant(ui->logFormatBox->isChecked()));
 
     // save history
     saveHistory(config);
+
+    // save user commands
+    saveUserCommands(config);
 
     config->endGroup();
 }
@@ -123,9 +156,13 @@ void TextTRView::loadSettings(QSettings *config)
     setTabWidth(config->value("TerminalTabWidth").toInt());
     setAutoIndent(config->value("TerminalAutoIndent").toBool());
     setIndentationGuides(config->value("TerminalIndentationGuides").toBool());
-    m_timeStamp = config->value("TerminalUseTimeStamp").toBool();
-    m_frameSeparator = config->value("TerminalFrameSeparator").toString();
-    m_timeStampFormat = config->value("TerminalTimeStampFormat").toString();
+
+    m_timeStampFormat = config->value("TerminalLogTimeFormat",
+                                      QStringLiteral("yyyy-MM-dd HH:mm:ss"))
+                             .toString();
+    if (m_timeStampFormat.isEmpty()) {
+        m_timeStampFormat = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+    }
 }
 
 void TextTRView::loadHistory(QSettings *config)
@@ -154,11 +191,162 @@ void TextTRView::saveHistory(QSettings *config)
     config->endGroup();
 }
 
+void TextTRView::loadUserCommands(QSettings *config)
+{
+    m_userCommands.clear();
+    config->beginGroup("UserCommands");
+    int count = config->beginReadArray("Items");
+    for (int i = 0; i < count; ++i) {
+        config->setArrayIndex(i);
+        QString cmd = config->value("data").toString();
+        if (!cmd.isEmpty()) {
+            m_userCommands.append(cmd);
+        }
+    }
+    config->endArray();
+    config->endGroup();
+    populateCommandBox();
+}
+
+void TextTRView::saveUserCommands(QSettings *config)
+{
+    config->beginGroup("UserCommands");
+    config->remove("");
+    config->beginWriteArray("Items");
+    for (int i = 0; i < m_userCommands.size(); ++i) {
+        config->setArrayIndex(i);
+        config->setValue("data", m_userCommands.at(i));
+    }
+    config->endArray();
+    config->endGroup();
+}
+
 void TextTRView::setHighlight(const QString &language)
 {
     // Send and Receive area highlight.
     ui->textEditTx->setHighLight(language);
     ui->textEditRx->setHighLight(language);
+}
+
+void TextTRView::appendLogEntry(LogDirection direction, const QString &text)
+{
+    if (text.isEmpty()) {
+        return;
+    }
+
+    LogEntry entry;
+    entry.direction = direction;
+    entry.timestamp = QDateTime::currentDateTime();
+    entry.content = text;
+    m_logEntries.append(entry);
+
+    refreshLogDisplay();
+}
+
+void TextTRView::refreshLogDisplay()
+{
+    QString buffer;
+    for (const LogEntry &entry : m_logEntries) {
+        if (!passesFilter(entry)) {
+            continue;
+        }
+
+        QString formatted = formatLogEntry(entry);
+        buffer.append(formatted);
+        if (m_logFormatEnabled && !formatted.endsWith('\n')) {
+            buffer.append('\n');
+        }
+    }
+
+    ui->textEditRx->setPlainText(buffer);
+    QTextCursor cursor = ui->textEditRx->textCursor();
+    cursor.movePosition(QTextCursor::End);
+    ui->textEditRx->setTextCursor(cursor);
+}
+
+bool TextTRView::passesFilter(const LogEntry &entry) const
+{
+    if (entry.direction == LogDirection::Receive) {
+        if (!m_showRxMessages) {
+            return false;
+        }
+    } else {
+        if (!m_logFormatEnabled || !m_showTxMessages) {
+            return false;
+        }
+    }
+
+    if (!m_filterText.isEmpty()) {
+        if (!entry.content.contains(m_filterText, Qt::CaseInsensitive)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+QString TextTRView::formatLogEntry(const LogEntry &entry) const
+{
+    if (!m_logFormatEnabled) {
+        return entry.content;
+    }
+
+    QString format = m_timeStampFormat;
+    if (format.isEmpty()) {
+        format = QStringLiteral("yyyy-MM-dd HH:mm:ss");
+    }
+
+    QString direction = entry.direction == LogDirection::Receive ? tr("RX") : tr("TX");
+    QString prefix = QStringLiteral("[%1][%2] ")
+                         .arg(entry.timestamp.toString(format), direction);
+
+    QStringList lines = entry.content.split('\n', Qt::KeepEmptyParts);
+    if (lines.isEmpty()) {
+        lines.append(QString());
+    }
+
+    for (QString &line : lines) {
+        line = prefix + line;
+    }
+
+    return lines.join('\n');
+}
+
+void TextTRView::populateCommandBox()
+{
+    QString previousSelection = ui->commandBox->currentText();
+    ui->commandBox->clear();
+
+    for (const QString &command : m_userCommands) {
+        ui->commandBox->addItem(command);
+    }
+
+    int index = ui->commandBox->findText(previousSelection);
+    if (index >= 0) {
+        ui->commandBox->setCurrentIndex(index);
+    } else if (!m_userCommands.isEmpty()) {
+        ui->commandBox->setCurrentIndex(0);
+    }
+
+    ui->commandBox->setEnabled(!m_userCommands.isEmpty());
+}
+
+bool TextTRView::findText(const QString &text, QTextDocument::FindFlags flags)
+{
+    if (text.isEmpty()) {
+        return false;
+    }
+
+    if (ui->textEditRx->find(text, flags)) {
+        return true;
+    }
+
+    QTextCursor cursor = ui->textEditRx->textCursor();
+    cursor.movePosition(flags.testFlag(QTextDocument::FindBackward)
+                           ? QTextCursor::End
+                           : QTextCursor::Start);
+    ui->textEditRx->setTextCursor(cursor);
+    return ui->textEditRx->find(text, flags);
 }
 
 void TextTRView::receiveData(const QByteArray &array)
@@ -177,11 +365,7 @@ void TextTRView::receiveData(const QByteArray &array)
         }
         arrayToHex(string, array, 16);
     }
-    if (m_timeStamp) {
-        appendTimeStamp(string);
-    } else {
-        ui->textEditRx->append(pre + string);
-    }
+    appendLogEntry(LogDirection::Receive, pre + string);
 }
 
 void TextTRView::clear()
@@ -189,6 +373,8 @@ void TextTRView::clear()
     ui->textEditRx->clear();
     m_asciiBuf->clear();
     m_hexCount = 0;
+    m_logEntries.clear();
+    refreshLogDisplay();
 }
 
 void TextTRView::setFontFamily(QString fontFamily, int size, QString style)
@@ -225,11 +411,116 @@ void TextTRView::sendData()
         array = QByteArray::fromHex(ui->textEditTx->toPlainText().toLatin1());
     }
     emit transmitData(array);
+
+    QString displayText = ui->textEditTx->toPlainText();
+    if (!displayText.isEmpty()) {
+        appendLogEntry(LogDirection::Transmit, displayText);
+    }
 }
 
 void TextTRView::onWrapBoxChanged(int status)
 {
     ui->textEditRx->setWrap(status);
+}
+
+void TextTRView::onLogFormatBoxToggled(bool checked)
+{
+    m_logFormatEnabled = checked;
+    ui->showTxBox->setEnabled(checked);
+    m_showTxMessages = ui->showTxBox->isChecked();
+    refreshLogDisplay();
+}
+
+void TextTRView::onFilterTextChanged(const QString &text)
+{
+    m_filterText = text;
+    refreshLogDisplay();
+}
+
+void TextTRView::onClearFilterButtonClicked()
+{
+    if (!ui->filterEdit->text().isEmpty()) {
+        ui->filterEdit->clear();
+    }
+}
+
+void TextTRView::onShowRxBoxToggled(bool checked)
+{
+    m_showRxMessages = checked;
+    refreshLogDisplay();
+}
+
+void TextTRView::onShowTxBoxToggled(bool checked)
+{
+    m_showTxMessages = checked;
+    refreshLogDisplay();
+}
+
+void TextTRView::onFindNext()
+{
+    QString text = ui->searchEdit->text();
+    if (text.isEmpty()) {
+        text = m_lastSearch;
+    } else {
+        m_lastSearch = text;
+    }
+    if (!text.isEmpty()) {
+        findText(text);
+    }
+}
+
+void TextTRView::onFindPrevious()
+{
+    QString text = ui->searchEdit->text();
+    if (text.isEmpty()) {
+        text = m_lastSearch;
+    } else {
+        m_lastSearch = text;
+    }
+    if (!text.isEmpty()) {
+        findText(text, QTextDocument::FindBackward);
+    }
+}
+
+void TextTRView::onSearchReturnPressed()
+{
+    onFindNext();
+}
+
+void TextTRView::onCommandBoxActivated(int index)
+{
+    if (index >= 0) {
+        ui->textEditTx->setPlainText(ui->commandBox->itemText(index));
+    }
+}
+
+void TextTRView::onSaveCommandClicked()
+{
+    QString command = ui->textEditTx->toPlainText().trimmed();
+    if (command.isEmpty()) {
+        QMessageBox::information(this, tr("Information"),
+                                 tr("The command is empty and cannot be saved."));
+        return;
+    }
+
+    int index = m_userCommands.indexOf(command);
+    if (index == -1) {
+        m_userCommands.prepend(command);
+        populateCommandBox();
+        ui->commandBox->setCurrentIndex(0);
+    } else {
+        ui->commandBox->setCurrentIndex(index);
+    }
+}
+
+void TextTRView::onManageCommandsClicked()
+{
+    CommandConfigDialog dialog(m_userCommands, this);
+    dialog.setPendingCommand(ui->textEditTx->toPlainText());
+    if (dialog.exec() == QDialog::Accepted) {
+        m_userCommands = dialog.commands();
+        populateCommandBox();
+    }
 }
 
 void TextTRView::onSendButtonClicked()
@@ -425,29 +716,6 @@ void TextTRView::arrayToString(QString &str, const QByteArray &array)
     }
 }
 
-void TextTRView::appendTimeStamp(const QString &string)
-{
-    QRegularExpression re(".+?(" + m_frameSeparator + "|$)");
-    QRegularExpressionMatch match = re.match(string);
-    QRegularExpressionMatchIterator it = re.globalMatch(string);
-    QString curTime = QDateTime::currentDateTime()
-            .toString(m_timeStampFormat);
-    while (it.hasNext()) {
-        QString span = it.next().captured(0);
-        if (m_nextFrame) {
-            ui->textEditRx->append(curTime);
-        }
-        m_nextFrame = span.indexOf(
-                    QRegularExpression(m_frameSeparator + "$")) != -1;
-        if (m_nextFrame) {
-            span.chop(m_frameSeparator.length());
-            span.append('\n');
-        }
-        ui->textEditRx->append(span);
-    }
-}
-
-// 保存文件
 void TextTRView::saveText(const QString &fname)
 {
     QFile file(fname);

--- a/SerialTool/src/views/texttr/texttrview.h
+++ b/SerialTool/src/views/texttr/texttrview.h
@@ -2,6 +2,10 @@
 #define TEXTTRVIEW_H
 
 #include "../abstractview.h"
+#include <QDateTime>
+#include <QList>
+#include <QStringList>
+#include <QTextDocument>
 
 namespace Ui {
 class TextTRView;
@@ -30,6 +34,17 @@ public:
     void saveFile(const QString &fileName, const QString &filter);
 
 private:
+    enum class LogDirection {
+        Receive,
+        Transmit
+    };
+
+    struct LogEntry {
+        LogDirection direction;
+        QDateTime timestamp;
+        QString content;
+    };
+
     void setFontFamily(QString fonts, int size, QString style);
     void setHighlight(const QString &language);
     void setTextCodec(const QString &name);
@@ -44,13 +59,19 @@ private:
     void arrayToString(QString &str, const QByteArray &arr);
     void loadHistory(QSettings *config);
     void saveHistory(QSettings *config);
+    void loadUserCommands(QSettings *config);
+    void saveUserCommands(QSettings *config);
+    void appendLogEntry(LogDirection direction, const QString &text);
+    void refreshLogDisplay();
+    bool passesFilter(const LogEntry &entry) const;
+    QString formatLogEntry(const LogEntry &entry) const;
+    void populateCommandBox();
+    bool findText(const QString &text, QTextDocument::FindFlags flags = {});
 
     void arrayToUTF8(QString &str, const QByteArray &array);
     void arrayToUTF16(QString &str, const QByteArray &array);
     void arrayToDualByte(QString &str, const QByteArray &array);
     void arrayToASCII(QString &str, const QByteArray &array);
-
-    void appendTimeStamp(const QString &string);
 
 private slots:
     void sendData();
@@ -59,6 +80,17 @@ private slots:
     void updateResendTimerStatus();
     void setResendInterval(int msc);
     void onHistoryBoxChanged(const QString &string);
+    void onLogFormatBoxToggled(bool checked);
+    void onFilterTextChanged(const QString &text);
+    void onClearFilterButtonClicked();
+    void onShowRxBoxToggled(bool checked);
+    void onShowTxBoxToggled(bool checked);
+    void onFindNext();
+    void onFindPrevious();
+    void onSearchReturnPressed();
+    void onCommandBoxActivated(int index);
+    void onSaveCommandClicked();
+    void onManageCommandsClicked();
 
 private:
     enum TextCodec {
@@ -75,8 +107,14 @@ private:
     QByteArray *m_asciiBuf;
     enum TextCodec m_textCodec;
     QByteArray m_codecName;
-    bool m_nextFrame = true, m_timeStamp = false;
-    QString m_timeStampFormat, m_frameSeparator;
+    QList<LogEntry> m_logEntries;
+    bool m_logFormatEnabled = false;
+    bool m_showRxMessages = true;
+    bool m_showTxMessages = true;
+    QString m_filterText;
+    QString m_timeStampFormat;
+    QStringList m_userCommands;
+    QString m_lastSearch;
 };
 
 #endif // TEXTTRVIEW_H

--- a/SerialTool/ui/texttrview.ui
+++ b/SerialTool/ui/texttrview.ui
@@ -120,6 +120,13 @@
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QCheckBox" name="logFormatBox">
+               <property name="text">
+                <string>Log Format</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -213,7 +220,107 @@
          <property name="verticalSpacing">
           <number>3</number>
          </property>
-         <item row="2" column="1">
+         <item row="0" column="0" colspan="2">
+          <widget class="TextEdit" name="textEditTx" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="focusPolicy">
+            <enum>Qt::StrongFocus</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_filter">
+           <item>
+            <widget class="QLineEdit" name="filterEdit">
+             <property name="placeholderText">
+              <string>Filter</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="clearFilterButton">
+             <property name="text">
+              <string>Clear</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="showRxBox">
+             <property name="text">
+              <string>Show RX</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="showTxBox">
+             <property name="text">
+              <string>Show TX</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_search">
+           <item>
+            <widget class="QLineEdit" name="searchEdit">
+             <property name="placeholderText">
+              <string>Search</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="findPrevButton">
+             <property name="text">
+              <string>Previous</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="findNextButton">
+             <property name="text">
+              <string>Next</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="0">
+          <layout class="QHBoxLayout" name="horizontalLayout_commands">
+           <item>
+            <widget class="QComboBox" name="commandBox"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="saveCommandButton">
+             <property name="text">
+              <string>Save Command</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="manageCommandsButton">
+             <property name="text">
+              <string>Manage...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="historyBox"/>
+           </item>
+          </layout>
+         </item>
+         <item row="3" column="1">
           <widget class="QPushButton" name="sendButton">
            <property name="enabled">
             <bool>false</bool>
@@ -226,22 +333,6 @@
            </property>
            <property name="text">
             <string>Send</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QComboBox" name="historyBox"/>
-         </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="TextEdit" name="textEditTx" native="true">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Ignored">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="focusPolicy">
-            <enum>Qt::StrongFocus</enum>
            </property>
           </widget>
          </item>
@@ -263,11 +354,22 @@
  </customwidgets>
  <tabstops>
   <tabstop>textEditTx</tabstop>
-  <tabstop>sendButton</tabstop>
+  <tabstop>filterEdit</tabstop>
+  <tabstop>clearFilterButton</tabstop>
+  <tabstop>showRxBox</tabstop>
+  <tabstop>showTxBox</tabstop>
+  <tabstop>searchEdit</tabstop>
+  <tabstop>findPrevButton</tabstop>
+  <tabstop>findNextButton</tabstop>
+  <tabstop>commandBox</tabstop>
+  <tabstop>saveCommandButton</tabstop>
+  <tabstop>manageCommandsButton</tabstop>
   <tabstop>historyBox</tabstop>
+  <tabstop>sendButton</tabstop>
   <tabstop>portReadAscii</tabstop>
   <tabstop>portReadHex</tabstop>
   <tabstop>wrapLineBox</tabstop>
+  <tabstop>logFormatBox</tabstop>
   <tabstop>portWriteAscii</tabstop>
   <tabstop>portWriteHex</tabstop>
   <tabstop>resendBox</tabstop>


### PR DESCRIPTION
## Summary
- add log format toggle with filtering and search controls to the Text Tx/Rx terminal view
- persist log settings and user command lists while updating the default configuration
- introduce a dialog for managing saved transmit commands and hook it into the project build

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ec590638108323ac909982bb146a15