### PR TITLE
Improve terminal log formatting and command metadata

### DIFF
--- a/SerialTool/src/views/texttr/commandconfigdialog.cpp
+++ b/SerialTool/src/views/texttr/commandconfigdialog.cpp
@@ -2,13 +2,22 @@
 
 #include <QAbstractItemView>
 #include <QDialogButtonBox>
+#include <QFormLayout>
 #include <QHBoxLayout>
 #include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
 #include <QVBoxLayout>
 
-CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *parent)
+namespace {
+
+constexpr int kCommandRole = Qt::UserRole;
+constexpr int kNameRole = Qt::UserRole + 1;
+constexpr int kRemarkRole = Qt::UserRole + 2;
+
+}
+
+CommandConfigDialog::CommandConfigDialog(const QVector<UserCommand> &commands, QWidget *parent)
     : QDialog(parent)
 {
     setWindowTitle(tr("Command Presets"));
@@ -18,18 +27,43 @@ CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *p
     auto *mainLayout = new QVBoxLayout(this);
 
     m_listWidget = new QListWidget(this);
-    m_listWidget->addItems(commands);
+    for (const UserCommand &command : commands) {
+        auto *item = new QListWidgetItem(displayText(command), m_listWidget);
+        item->setData(kCommandRole, command.command);
+        item->setData(kNameRole, command.name);
+        item->setData(kRemarkRole, command.remark);
+        if (!command.remark.isEmpty()) {
+            item->setToolTip(command.remark);
+        }
+    }
     m_listWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
     mainLayout->addWidget(m_listWidget);
 
-    auto *inputLayout = new QHBoxLayout();
-    m_inputEdit = new QLineEdit(this);
-    m_inputEdit->setPlaceholderText(tr("New command"));
-    inputLayout->addWidget(m_inputEdit);
+    auto *formLayout = new QFormLayout();
+    m_nameEdit = new QLineEdit(this);
+    m_nameEdit->setPlaceholderText(tr("Command name"));
+    formLayout->addRow(tr("Name"), m_nameEdit);
+
+    m_commandEdit = new QLineEdit(this);
+    m_commandEdit->setPlaceholderText(tr("Command"));
+    formLayout->addRow(tr("Command"), m_commandEdit);
+
+    m_remarkEdit = new QLineEdit(this);
+    m_remarkEdit->setPlaceholderText(tr("Remark"));
+    formLayout->addRow(tr("Remark"), m_remarkEdit);
+
+    mainLayout->addLayout(formLayout);
+
+    auto *buttonLayout = new QHBoxLayout();
+    buttonLayout->addStretch();
 
     m_addButton = new QPushButton(tr("Add"), this);
-    inputLayout->addWidget(m_addButton);
-    mainLayout->addLayout(inputLayout);
+    buttonLayout->addWidget(m_addButton);
+
+    m_updateButton = new QPushButton(tr("Update"), this);
+    buttonLayout->addWidget(m_updateButton);
+
+    mainLayout->addLayout(buttonLayout);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
     m_removeButton = new QPushButton(tr("Remove"), this);
@@ -37,32 +71,78 @@ CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *p
     mainLayout->addWidget(buttonBox);
 
     connect(m_addButton, &QPushButton::clicked, this, &CommandConfigDialog::addCommand);
+    connect(m_updateButton, &QPushButton::clicked, this, &CommandConfigDialog::updateCommand);
     connect(m_removeButton, &QPushButton::clicked, this, &CommandConfigDialog::removeSelected);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &CommandConfigDialog::accept);
-    connect(m_listWidget, &QListWidget::itemSelectionChanged, this, &CommandConfigDialog::updateButtonStates);
-    connect(m_inputEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::updateButtonStates);
+    connect(m_listWidget, &QListWidget::itemSelectionChanged, this, &CommandConfigDialog::onSelectionChanged);
+    connect(m_nameEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::onEditFieldsChanged);
+    connect(m_commandEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::onEditFieldsChanged);
+    connect(m_remarkEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::onEditFieldsChanged);
 
     updateButtonStates();
 }
 
-QStringList CommandConfigDialog::commands() const
+QVector<UserCommand> CommandConfigDialog::commands() const
 {
-    QStringList result;
+    QVector<UserCommand> result;
     result.reserve(m_listWidget->count());
     for (int i = 0; i < m_listWidget->count(); ++i) {
-        result.append(m_listWidget->item(i)->text());
+        const QListWidgetItem *item = m_listWidget->item(i);
+        UserCommand command;
+        command.command = item->data(kCommandRole).toString();
+        command.name = item->data(kNameRole).toString();
+        command.remark = item->data(kRemarkRole).toString();
+        result.append(command);
     }
     return result;
 }
 
 void CommandConfigDialog::addCommand()
 {
-    const QString text = m_inputEdit->text().trimmed();
-    if (!canAdd(text)) {
+    const QString name = m_nameEdit->text().trimmed();
+    const QString command = m_commandEdit->text().trimmed();
+    const QString remark = m_remarkEdit->text().trimmed();
+
+    if (!canAdd(command)) {
         return;
     }
-    m_listWidget->addItem(text);
-    m_inputEdit->clear();
+    UserCommand value{name, command, remark};
+    auto *item = new QListWidgetItem(displayText(value), m_listWidget);
+    item->setData(kCommandRole, command);
+    item->setData(kNameRole, name);
+    item->setData(kRemarkRole, remark);
+    item->setToolTip(remark);
+
+    m_listWidget->setCurrentItem(item);
+    m_nameEdit->clear();
+    m_commandEdit->clear();
+    m_remarkEdit->clear();
+    updateButtonStates();
+}
+
+void CommandConfigDialog::updateCommand()
+{
+    const auto selected = m_listWidget->selectedItems();
+    if (selected.size() != 1) {
+        return;
+    }
+
+    QListWidgetItem *item = selected.first();
+    const QString name = m_nameEdit->text().trimmed();
+    const QString command = m_commandEdit->text().trimmed();
+    const QString remark = m_remarkEdit->text().trimmed();
+
+    if (!canUpdate(command, item)) {
+        return;
+    }
+
+    UserCommand value{name, command, remark};
+    item->setText(displayText(value));
+    item->setData(kCommandRole, command);
+    item->setData(kNameRole, name);
+    item->setData(kRemarkRole, remark);
+    item->setToolTip(remark);
+
     updateButtonStates();
 }
 
@@ -72,26 +152,86 @@ void CommandConfigDialog::removeSelected()
     for (QListWidgetItem *item : selected) {
         delete item;
     }
+    onSelectionChanged();
+    updateButtonStates();
+}
+
+void CommandConfigDialog::onSelectionChanged()
+{
+    const auto selected = m_listWidget->selectedItems();
+    if (selected.size() == 1) {
+        QListWidgetItem *item = selected.first();
+        m_nameEdit->setText(item->data(kNameRole).toString());
+        m_commandEdit->setText(item->data(kCommandRole).toString());
+        m_remarkEdit->setText(item->data(kRemarkRole).toString());
+    } else if (selected.isEmpty()) {
+        m_nameEdit->clear();
+        m_commandEdit->clear();
+        m_remarkEdit->clear();
+    }
+    updateButtonStates();
+}
+
+void CommandConfigDialog::onEditFieldsChanged()
+{
     updateButtonStates();
 }
 
 void CommandConfigDialog::updateButtonStates()
 {
-    const QString text = m_inputEdit->text().trimmed();
-    m_addButton->setEnabled(canAdd(text));
-    m_removeButton->setEnabled(!m_listWidget->selectedItems().isEmpty());
+    const QString command = m_commandEdit->text().trimmed();
+    const auto selected = m_listWidget->selectedItems();
+    QListWidgetItem *singleSelection = selected.size() == 1 ? selected.first() : nullptr;
+    m_addButton->setEnabled(canAdd(command));
+    m_updateButton->setEnabled(canUpdate(command, singleSelection));
+    m_removeButton->setEnabled(!selected.isEmpty());
 }
 
-bool CommandConfigDialog::canAdd(const QString &text) const
+bool CommandConfigDialog::canAdd(const QString &commandText) const
 {
-    if (text.isEmpty()) {
+    if (commandText.isEmpty()) {
+        return false;
+    }
+    return !commandExists(commandText);
+}
+
+bool CommandConfigDialog::canUpdate(const QString &commandText, const QListWidgetItem *current) const
+{
+    if (!current || commandText.isEmpty()) {
+        return false;
+    }
+    return !commandExists(commandText, current);
+}
+
+bool CommandConfigDialog::commandExists(const QString &commandText, const QListWidgetItem *exclude) const
+{
+    if (commandText.isEmpty()) {
         return false;
     }
     for (int i = 0; i < m_listWidget->count(); ++i) {
-        if (m_listWidget->item(i)->text() == text) {
-            return false;
+        QListWidgetItem *item = m_listWidget->item(i);
+        if (item == exclude) {
+            continue;
+        }
+        if (item->data(kCommandRole).toString() == commandText) {
+            return true;
         }
     }
-    return true;
+    return false;
+}
+
+QString CommandConfigDialog::displayText(const UserCommand &command)
+{
+    QString text = command.name.isEmpty() ? command.command : command.name;
+    if (!command.remark.isEmpty()) {
+        if (!text.isEmpty()) {
+            text.append(QStringLiteral(" — "));
+        }
+        text.append(command.remark);
+    }
+    if (text.isEmpty()) {
+        text = command.command;
+    }
+    return text;
 }
 

--- a/SerialTool/src/views/texttr/commandconfigdialog.h
+++ b/SerialTool/src/views/texttr/commandconfigdialog.h
@@ -2,32 +2,45 @@
 #define COMMANDCONFIGDIALOG_H
 
 #include <QDialog>
+#include <QVector>
+
+#include "usercommand.h"
 
 class QListWidget;
 class QLineEdit;
 class QPushButton;
+class QListWidgetItem;
 
 class CommandConfigDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit CommandConfigDialog(const QStringList &commands, QWidget *parent = nullptr);
+    explicit CommandConfigDialog(const QVector<UserCommand> &commands, QWidget *parent = nullptr);
 
-    QStringList commands() const;
+    QVector<UserCommand> commands() const;
 
 private slots:
     void addCommand();
+    void updateCommand();
     void removeSelected();
+    void onSelectionChanged();
+    void onEditFieldsChanged();
     void updateButtonStates();
 
 private:
-    bool canAdd(const QString &text) const;
+    bool canAdd(const QString &commandText) const;
+    bool canUpdate(const QString &commandText, const QListWidgetItem *current) const;
+    bool commandExists(const QString &commandText, const QListWidgetItem *exclude = nullptr) const;
+    static QString displayText(const UserCommand &command);
 
 private:
     QListWidget *m_listWidget;
-    QLineEdit *m_inputEdit;
+    QLineEdit *m_nameEdit;
+    QLineEdit *m_commandEdit;
+    QLineEdit *m_remarkEdit;
     QPushButton *m_addButton;
+    QPushButton *m_updateButton;
     QPushButton *m_removeButton;
 };
 

--- a/SerialTool/src/views/texttr/texttrview.cpp
+++ b/SerialTool/src/views/texttr/texttrview.cpp
@@ -2,10 +2,17 @@
 #include "ui_texttrview.h"
 #include "commandconfigdialog.h"
 #include <QCheckBox>
+#include <QColor>
+#include <QComboBox>
 #include <QDateTime>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QFile>
+#include <QFormLayout>
 #include <QKeyEvent>
+#include <QLabel>
 #include <QLineEdit>
+#include <QtCore/QOverload>
 #include <QPushButton>
 #include <QRadioButton>
 #include <QScrollBar>
@@ -14,10 +21,11 @@
 #include <QStandardItem>
 #include <QStandardItemModel>
 #include <QTextCodec>
-#include <QTextDocument>
 #include <QTextCursor>
+#include <QTextDocument>
 #include <QTimer>
 #include <QToolButton>
+#include <QVBoxLayout>
 
 TextTRView::TextTRView(QWidget *parent) :
     AbstractView(parent),
@@ -38,7 +46,8 @@ TextTRView::TextTRView(QWidget *parent) :
     connect(ui->resendBox, &QCheckBox::stateChanged, this, &TextTRView::updateResendTimerStatus);
     QObject::connect(m_resendTimer, &QTimer::timeout, this, &TextTRView::sendData);
     connect(ui->resendIntervalBox, SIGNAL(valueChanged(int)), this, SLOT(setResendInterval(int)));
-    connect(ui->historyBox, SIGNAL(activated(const QString &)), this, SLOT(onHistoryBoxChanged(const QString &)));
+    connect(ui->historyBox, QOverload<int>::of(&QComboBox::activated),
+            this, &TextTRView::onHistoryBoxIndexChanged);
     connect(ui->filterLineEdit, &QLineEdit::textChanged, this, &TextTRView::onFilterTextChanged);
     connect(ui->clearFilterButton, &QToolButton::clicked, this, &TextTRView::onClearFilterClicked);
     connect(ui->searchLineEdit, &QLineEdit::returnPressed, this, &TextTRView::onSearchReturnPressed);
@@ -195,9 +204,18 @@ void TextTRView::loadUserCommands(QSettings *config)
     int count = config->beginReadArray("Items");
     for (int i = 0; i < count; ++i) {
         config->setArrayIndex(i);
-        const QString value = config->value("data").toString();
-        if (!value.isEmpty()) {
-            m_userCommands.append(value);
+        UserCommand command;
+        command.command = config->value("data").toString();
+        command.name = config->value("name").toString();
+        if (command.name.isEmpty()) {
+            command.name = config->value("title").toString();
+        }
+        command.remark = config->value("remark").toString();
+        if (command.remark.isEmpty()) {
+            command.remark = config->value("note").toString();
+        }
+        if (!command.command.isEmpty()) {
+            m_userCommands.append(command);
         }
     }
     config->endArray();
@@ -210,7 +228,10 @@ void TextTRView::saveUserCommands(QSettings *config)
     config->beginWriteArray("Items");
     for (int i = 0; i < m_userCommands.size(); ++i) {
         config->setArrayIndex(i);
-        config->setValue("data", m_userCommands.at(i));
+        const UserCommand &command = m_userCommands.at(i);
+        config->setValue("data", command.command);
+        config->setValue("name", command.name);
+        config->setValue("remark", command.remark);
     }
     config->endArray();
     config->endGroup();
@@ -233,8 +254,26 @@ void TextTRView::refreshCommandBox()
     }
     model->clear();
 
-    for (const QString &command : m_userCommands) {
-        auto *item = new QStandardItem(command);
+    auto displayFor = [](const UserCommand &command) {
+        QString display = command.name.isEmpty() ? command.command : command.name;
+        if (!command.remark.isEmpty()) {
+            if (!display.isEmpty()) {
+                display.append(QStringLiteral(" — "));
+            }
+            display.append(command.remark);
+        }
+        if (display.isEmpty()) {
+            display = command.command;
+        }
+        return display;
+    };
+
+    for (const UserCommand &command : m_userCommands) {
+        auto *item = new QStandardItem(displayFor(command));
+        item->setData(command.command, Qt::UserRole);
+        if (!command.remark.isEmpty()) {
+            item->setToolTip(command.remark);
+        }
         model->appendRow(item);
     }
 
@@ -246,6 +285,7 @@ void TextTRView::refreshCommandBox()
 
     for (const QString &history : m_historyRecords) {
         auto *item = new QStandardItem(history);
+        item->setData(history, Qt::UserRole);
         model->appendRow(item);
     }
 
@@ -266,17 +306,21 @@ void TextTRView::rememberHistory(const QString &command)
     refreshCommandBox();
 }
 
-void TextTRView::appendReceivedEntry(const QString &text)
+void TextTRView::appendEntry(const QString &text, MessageDirection direction, MessageEncoding encoding)
 {
     if (text.isEmpty()) {
         return;
     }
-    QString entry = text;
-    if (!entry.endsWith('\n')) {
-        entry.append('\n');
+
+    LogEntry entry;
+    entry.timestamp = QDateTime::currentDateTime();
+    entry.text = text;
+    if (!entry.text.endsWith('\n')) {
+        entry.text.append('\n');
     }
-    m_receivedTexts.append(entry);
-    m_entryTimestamps.append(QDateTime::currentDateTime());
+    entry.direction = direction;
+    entry.encoding = encoding;
+    m_entries.append(entry);
     rebuildReceiveView();
 }
 
@@ -285,35 +329,68 @@ void TextTRView::rebuildReceiveView()
     if (!ui) {
         return;
     }
-    const QString filter = ui->filterLineEdit->text();
-    const bool atBottom = ui->textEditRx->verticalScrollBar()->value() ==
-            ui->textEditRx->verticalScrollBar()->maximum();
 
-    QString buffer;
-    buffer.reserve(m_receivedTexts.size() * 32);
-    for (int i = 0; i < m_receivedTexts.size(); ++i) {
-        const QString &raw = m_receivedTexts.at(i);
-        if (!filter.isEmpty() && !raw.contains(filter, Qt::CaseInsensitive)) {
-            continue;
+    const QString filter = ui->filterLineEdit->text();
+    auto *edit = ui->textEditRx;
+    const bool atBottom = edit->verticalScrollBar()->value() == edit->verticalScrollBar()->maximum();
+
+    edit->blockSignals(true);
+    QTextDocument *document = edit->document();
+    document->clear();
+    QTextCursor cursor(document);
+
+    for (const LogEntry &entry : m_entries) {
+        const QString header = formatEntry(entry);
+        if (!filter.isEmpty()) {
+            if (!header.contains(filter, Qt::CaseInsensitive) &&
+                !entry.text.contains(filter, Qt::CaseInsensitive)) {
+                continue;
+            }
         }
-        buffer.append(formatEntry(m_entryTimestamps.at(i), raw));
+
+        const QTextCharFormat format = formatFor(entry);
+        cursor.insertText(header, format);
+        cursor.insertText(QStringLiteral("\n"), format);
+        cursor.insertText(entry.text, format);
     }
 
-    ui->textEditRx->setPlainText(buffer);
+    edit->blockSignals(false);
+
     if (atBottom) {
-        QTextCursor cursor = ui->textEditRx->textCursor();
-        cursor.movePosition(QTextCursor::End);
-        ui->textEditRx->setTextCursor(cursor);
-        ui->textEditRx->verticalScrollBar()->setValue(ui->textEditRx->verticalScrollBar()->maximum());
+        QTextCursor endCursor = edit->textCursor();
+        endCursor.movePosition(QTextCursor::End);
+        edit->setTextCursor(endCursor);
+        edit->verticalScrollBar()->setValue(edit->verticalScrollBar()->maximum());
     }
 }
 
-QString TextTRView::formatEntry(const QDateTime &timestamp, const QString &text) const
+QString TextTRView::formatEntry(const LogEntry &entry) const
 {
-    if (!m_logWithTimestamp) {
-        return text;
+    const QString direction = entry.direction == MessageDirection::Receive ? QStringLiteral("RX")
+                                                                            : QStringLiteral("TX");
+    const QString encoding = entry.encoding == MessageEncoding::Hex ? QStringLiteral("HEX")
+                                                                    : QStringLiteral("ASCII");
+    QString header;
+    if (m_logWithTimestamp) {
+        header = QStringLiteral("[%1]# ").arg(entry.timestamp.toString(m_timeStampFormat));
     }
-    return QStringLiteral("[%1] %2").arg(timestamp.toString(m_timeStampFormat), text);
+    header.append(direction);
+    header.append(QLatin1Char(' '));
+    header.append(encoding);
+    return header;
+}
+
+QTextCharFormat TextTRView::formatFor(const LogEntry &entry) const
+{
+    QTextCharFormat format;
+    if (entry.direction == MessageDirection::Receive) {
+        format.setForeground(QColor(QStringLiteral("#1b5e20")));
+        format.setBackground(QColor(QStringLiteral("#e8f5e9")));
+    } else {
+        format.setForeground(QColor(QStringLiteral("#0d47a1")));
+        format.setBackground(QColor(QStringLiteral("#e3f2fd")));
+    }
+    return format;
 }
 
 void TextTRView::findInReceive(bool forward)
@@ -337,6 +414,7 @@ void TextTRView::findInReceive(bool forward)
 void TextTRView::receiveData(const QByteArray &array)
 {
     QString string, pre;
+    MessageEncoding encoding = MessageEncoding::Ascii;
     if (ui->portReadAscii->isChecked()) {
         if (m_hexCount > 0) {
             pre = '\n';
@@ -344,13 +422,14 @@ void TextTRView::receiveData(const QByteArray &array)
         m_hexCount = -1;
         arrayToString(string, array);
     } else {
+        encoding = MessageEncoding::Hex;
         if (m_hexCount == -1) {
             m_hexCount = 0;
             pre = '\n';
         }
         arrayToHex(string, array, 16);
     }
-    appendReceivedEntry(pre + string);
+    appendEntry(pre + string, MessageDirection::Receive, encoding);
 }
 
 void TextTRView::clear()
@@ -358,8 +437,7 @@ void TextTRView::clear()
     ui->textEditRx->clear();
     m_asciiBuf->clear();
     m_hexCount = 0;
-    m_receivedTexts.clear();
-    m_entryTimestamps.clear();
+    m_entries.clear();
     rebuildReceiveView();
 }
 
@@ -385,16 +463,23 @@ void TextTRView::setEnabled(bool enabled)
 void TextTRView::sendData()
 {
     QByteArray array;
+    const QString text = ui->textEditTx->toPlainText();
 
     if (ui->portWriteAscii->isChecked() == true) {
         if(m_codecName == "ASCII"){
-            array = ui->textEditTx->toPlainText().toLatin1();
+            array = text.toLatin1();
         }else{
             QTextCodec *code = QTextCodec::codecForName(m_codecName);
-            array = code->fromUnicode(ui->textEditTx->toPlainText());
+            array = code->fromUnicode(text);
         }
     } else {
-        array = QByteArray::fromHex(ui->textEditTx->toPlainText().toLatin1());
+        array = QByteArray::fromHex(text.toLatin1());
+    }
+
+    if (!text.isEmpty()) {
+        appendEntry(text,
+                    MessageDirection::Transmit,
+                    ui->portWriteHex->isChecked() ? MessageEncoding::Hex : MessageEncoding::Ascii);
     }
     emit transmitData(array);
 }
@@ -451,9 +536,25 @@ void TextTRView::setTextCodec(const QString &name)
     }
 }
 
-void TextTRView::onHistoryBoxChanged(const QString &string)
+void TextTRView::onHistoryBoxIndexChanged(int index)
 {
-    ui->textEditTx->setPlainText(string);
+    if (index < 0) {
+        return;
+    }
+    auto *model = qobject_cast<QStandardItemModel *>(ui->historyBox->model());
+    if (!model) {
+        return;
+    }
+    QStandardItem *item = model->item(index);
+    if (!item) {
+        return;
+    }
+    const QVariant commandData = item->data(Qt::UserRole);
+    if (!commandData.isValid()) {
+        ui->historyBox->setCurrentIndex(-1);
+        return;
+    }
+    ui->textEditTx->setPlainText(commandData.toString());
 }
 
 void TextTRView::onFilterTextChanged(const QString &)
@@ -479,14 +580,65 @@ void TextTRView::onLogTimestampToggled(bool enabled)
 
 void TextTRView::onSaveCommandClicked()
 {
-    const QString command = ui->textEditTx->toPlainText().trimmed();
-    if (command.isEmpty()) {
+    const QString commandText = ui->textEditTx->toPlainText().trimmed();
+    if (commandText.isEmpty()) {
         return;
     }
-    if (!m_userCommands.contains(command)) {
-        m_userCommands.prepend(command);
-        refreshCommandBox();
+
+    QDialog dialog(this);
+    dialog.setWindowTitle(tr("Save Command"));
+    dialog.setModal(true);
+
+    auto *layout = new QVBoxLayout(&dialog);
+    auto *formLayout = new QFormLayout();
+
+    auto *nameEdit = new QLineEdit(&dialog);
+    nameEdit->setPlaceholderText(tr("Command name"));
+
+    auto *remarkEdit = new QLineEdit(&dialog);
+    remarkEdit->setPlaceholderText(tr("Remark"));
+
+    for (const UserCommand &existing : m_userCommands) {
+        if (existing.command == commandText) {
+            nameEdit->setText(existing.name);
+            remarkEdit->setText(existing.remark);
+            break;
+        }
     }
+
+    formLayout->addRow(tr("Name"), nameEdit);
+
+    auto *commandLabel = new QLabel(commandText, &dialog);
+    commandLabel->setWordWrap(true);
+    commandLabel->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    formLayout->addRow(tr("Command"), commandLabel);
+
+    formLayout->addRow(tr("Remark"), remarkEdit);
+
+    layout->addLayout(formLayout);
+
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, &dialog);
+    layout->addWidget(buttonBox);
+    connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    UserCommand command;
+    command.command = commandText;
+    command.name = nameEdit->text().trimmed();
+    command.remark = remarkEdit->text().trimmed();
+
+    for (int i = 0; i < m_userCommands.size(); ++i) {
+        if (m_userCommands.at(i).command == command.command) {
+            m_userCommands.removeAt(i);
+            break;
+        }
+    }
+    m_userCommands.prepend(command);
+    refreshCommandBox();
 }
 
 void TextTRView::onManageCommandsClicked()

--- a/SerialTool/src/views/texttr/texttrview.h
+++ b/SerialTool/src/views/texttr/texttrview.h
@@ -2,10 +2,12 @@
 #define TEXTTRVIEW_H
 
 #include "../abstractview.h"
+#include "usercommand.h"
 
 #include <QByteArray>
 #include <QDateTime>
 #include <QStringList>
+#include <QTextCharFormat>
 #include <QVector>
 
 namespace Ui {
@@ -44,9 +46,27 @@ private:
     void setIndentationGuides(bool enable);
     void saveText(const QString &fname);
 
-    void appendReceivedEntry(const QString &text);
+    enum class MessageDirection {
+        Receive,
+        Transmit
+    };
+
+    enum class MessageEncoding {
+        Ascii,
+        Hex
+    };
+
+    struct LogEntry {
+        QDateTime timestamp;
+        QString text;
+        MessageDirection direction = MessageDirection::Receive;
+        MessageEncoding encoding = MessageEncoding::Ascii;
+    };
+
+    void appendEntry(const QString &text, MessageDirection direction, MessageEncoding encoding);
     void rebuildReceiveView();
-    QString formatEntry(const QDateTime &timestamp, const QString &text) const;
+    QString formatEntry(const LogEntry &entry) const;
+    QTextCharFormat formatFor(const LogEntry &entry) const;
     void refreshCommandBox();
     void loadUserCommands(QSettings *config);
     void saveUserCommands(QSettings *config);
@@ -70,7 +90,7 @@ private slots:
     void onSendButtonClicked();
     void updateResendTimerStatus();
     void setResendInterval(int msc);
-    void onHistoryBoxChanged(const QString &string);
+    void onHistoryBoxIndexChanged(int index);
     void onFilterTextChanged(const QString &text);
     void onClearFilterClicked();
     void onSearchReturnPressed();
@@ -95,10 +115,9 @@ private:
     QByteArray m_codecName;
     bool m_logWithTimestamp = false;
     QString m_timeStampFormat;
-    QVector<QDateTime> m_entryTimestamps;
-    QStringList m_receivedTexts;
+    QVector<LogEntry> m_entries;
     QStringList m_historyRecords;
-    QStringList m_userCommands;
+    QVector<UserCommand> m_userCommands;
 };
 
 #endif // TEXTTRVIEW_H

--- a/SerialTool/src/views/texttr/usercommand.h
+++ b/SerialTool/src/views/texttr/usercommand.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <QString>
+
+struct UserCommand
+{
+    QString name;
+    QString command;
+    QString remark;
+};
+


### PR DESCRIPTION
## Summary
- restyle terminal entries to show timestamp, direction, and encoding with colored receive/transmit backgrounds
- log transmitted payloads in the receive pane while preserving filtering behavior
- allow command presets to store names and remarks and update the management dialog UI accordingly

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ec92fbb39883239c183910dc820952