### PR TITLE
Improve text transfer log formatting and command metadata input

### DIFF
--- a/SerialTool/SerialTool.pro
+++ b/SerialTool/SerialTool.pro
@@ -65,6 +65,7 @@ SOURCES += \
     #src/views/scriptextension/scriptextensionview.cpp \
     src/views/texttr/textedit.cpp \
     src/views/texttr/commandconfigdialog.cpp \
+    src/views/texttr/commandeditdialog.cpp \
     src/views/texttr/texttrview.cpp \
     src/views/terminal/terminalview.cpp \
     src/views/terminal/qvterminal/qvtchar.cpp \
@@ -106,6 +107,8 @@ HEADERS  += \
     #src/views/scriptextension/scriptextensionview.h \
     src/views/texttr/textedit.h \
     src/views/texttr/commandconfigdialog.h \
+    src/views/texttr/commandeditdialog.h \
+    src/views/texttr/commandpreset.h \
     src/views/texttr/texttrview.h \
     src/views/terminal/terminalview.h \
     src/views/terminal/qvterminal/qvtchar.h \

--- a/SerialTool/src/views/texttr/commandconfigdialog.cpp
+++ b/SerialTool/src/views/texttr/commandconfigdialog.cpp
@@ -1,14 +1,31 @@
 #include "commandconfigdialog.h"
+#include "commandeditdialog.h"
 
 #include <QAbstractItemView>
 #include <QDialogButtonBox>
 #include <QHBoxLayout>
-#include <QLineEdit>
 #include <QListWidget>
 #include <QPushButton>
+#include <QVariant>
 #include <QVBoxLayout>
 
-CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *parent)
+namespace {
+QString displayTextForPreset(const CommandPreset &preset)
+{
+    if (!preset.name.isEmpty() && !preset.note.isEmpty()) {
+        return QStringLiteral("%1 — %2").arg(preset.name, preset.note);
+    }
+    if (!preset.name.isEmpty()) {
+        return preset.name;
+    }
+    if (!preset.note.isEmpty()) {
+        return QStringLiteral("%1 — %2").arg(preset.command, preset.note);
+    }
+    return preset.command;
+}
+}
+
+CommandConfigDialog::CommandConfigDialog(const QVector<CommandPreset> &commands, QWidget *parent)
     : QDialog(parent)
 {
     setWindowTitle(tr("Command Presets"));
@@ -18,51 +35,64 @@ CommandConfigDialog::CommandConfigDialog(const QStringList &commands, QWidget *p
     auto *mainLayout = new QVBoxLayout(this);
 
     m_listWidget = new QListWidget(this);
-    m_listWidget->addItems(commands);
     m_listWidget->setSelectionMode(QAbstractItemView::ExtendedSelection);
     mainLayout->addWidget(m_listWidget);
 
-    auto *inputLayout = new QHBoxLayout();
-    m_inputEdit = new QLineEdit(this);
-    m_inputEdit->setPlaceholderText(tr("New command"));
-    inputLayout->addWidget(m_inputEdit);
-
+    auto *buttonLayout = new QHBoxLayout();
     m_addButton = new QPushButton(tr("Add"), this);
-    inputLayout->addWidget(m_addButton);
-    mainLayout->addLayout(inputLayout);
+    buttonLayout->addWidget(m_addButton);
+    m_removeButton = new QPushButton(tr("Remove"), this);
+    buttonLayout->addWidget(m_removeButton);
+    buttonLayout->addStretch(1);
+    mainLayout->addLayout(buttonLayout);
 
     auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
-    m_removeButton = new QPushButton(tr("Remove"), this);
-    buttonBox->addButton(m_removeButton, QDialogButtonBox::ActionRole);
     mainLayout->addWidget(buttonBox);
 
     connect(m_addButton, &QPushButton::clicked, this, &CommandConfigDialog::addCommand);
     connect(m_removeButton, &QPushButton::clicked, this, &CommandConfigDialog::removeSelected);
     connect(buttonBox, &QDialogButtonBox::rejected, this, &CommandConfigDialog::accept);
     connect(m_listWidget, &QListWidget::itemSelectionChanged, this, &CommandConfigDialog::updateButtonStates);
-    connect(m_inputEdit, &QLineEdit::textChanged, this, &CommandConfigDialog::updateButtonStates);
+
+    for (const CommandPreset &preset : commands) {
+        appendListItem(preset);
+    }
 
     updateButtonStates();
 }
 
-QStringList CommandConfigDialog::commands() const
+QVector<CommandPreset> CommandConfigDialog::commands() const
 {
-    QStringList result;
+    QVector<CommandPreset> result;
     result.reserve(m_listWidget->count());
     for (int i = 0; i < m_listWidget->count(); ++i) {
-        result.append(m_listWidget->item(i)->text());
+        result.append(presetFromItem(i));
     }
     return result;
 }
 
 void CommandConfigDialog::addCommand()
 {
-    const QString text = m_inputEdit->text().trimmed();
-    if (!canAdd(text)) {
+    CommandEditDialog dialog(this);
+    if (dialog.exec() != QDialog::Accepted) {
         return;
     }
-    m_listWidget->addItem(text);
-    m_inputEdit->clear();
+    const CommandPreset preset = dialog.preset();
+    if (preset.command.isEmpty()) {
+        return;
+    }
+    for (int i = 0; i < m_listWidget->count(); ++i) {
+        CommandPreset existing = presetFromItem(i);
+        const bool sameName = !preset.name.isEmpty() && !existing.name.isEmpty() &&
+                existing.name.compare(preset.name, Qt::CaseInsensitive) == 0;
+        const bool sameCommand = existing.command == preset.command;
+        if (sameName || sameCommand) {
+            applyPresetToItem(m_listWidget->item(i), preset);
+            updateButtonStates();
+            return;
+        }
+    }
+    appendListItem(preset);
     updateButtonStates();
 }
 
@@ -77,21 +107,39 @@ void CommandConfigDialog::removeSelected()
 
 void CommandConfigDialog::updateButtonStates()
 {
-    const QString text = m_inputEdit->text().trimmed();
-    m_addButton->setEnabled(canAdd(text));
     m_removeButton->setEnabled(!m_listWidget->selectedItems().isEmpty());
 }
 
-bool CommandConfigDialog::canAdd(const QString &text) const
+void CommandConfigDialog::appendListItem(const CommandPreset &preset)
 {
-    if (text.isEmpty()) {
-        return false;
+    auto *item = new QListWidgetItem(m_listWidget);
+    applyPresetToItem(item, preset);
+}
+
+void CommandConfigDialog::applyPresetToItem(QListWidgetItem *item, const CommandPreset &preset) const
+{
+    if (!item) {
+        return;
     }
-    for (int i = 0; i < m_listWidget->count(); ++i) {
-        if (m_listWidget->item(i)->text() == text) {
-            return false;
-        }
+    item->setText(displayTextForPreset(preset));
+    QVariantMap map;
+    map.insert(QStringLiteral("name"), preset.name);
+    map.insert(QStringLiteral("command"), preset.command);
+    map.insert(QStringLiteral("note"), preset.note);
+    item->setData(Qt::UserRole, map);
+}
+
+CommandPreset CommandConfigDialog::presetFromItem(int row) const
+{
+    CommandPreset preset;
+    if (row < 0 || row >= m_listWidget->count()) {
+        return preset;
     }
-    return true;
+    const QVariant data = m_listWidget->item(row)->data(Qt::UserRole);
+    const QVariantMap map = data.toMap();
+    preset.name = map.value(QStringLiteral("name")).toString();
+    preset.command = map.value(QStringLiteral("command")).toString();
+    preset.note = map.value(QStringLiteral("note")).toString();
+    return preset;
 }
 

--- a/SerialTool/src/views/texttr/commandconfigdialog.h
+++ b/SerialTool/src/views/texttr/commandconfigdialog.h
@@ -1,10 +1,13 @@
 #ifndef COMMANDCONFIGDIALOG_H
 #define COMMANDCONFIGDIALOG_H
 
+#include "commandpreset.h"
+
 #include <QDialog>
+#include <QVector>
 
 class QListWidget;
-class QLineEdit;
+class QListWidgetItem;
 class QPushButton;
 
 class CommandConfigDialog : public QDialog
@@ -12,9 +15,9 @@ class CommandConfigDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit CommandConfigDialog(const QStringList &commands, QWidget *parent = nullptr);
+    explicit CommandConfigDialog(const QVector<CommandPreset> &commands, QWidget *parent = nullptr);
 
-    QStringList commands() const;
+    QVector<CommandPreset> commands() const;
 
 private slots:
     void addCommand();
@@ -22,11 +25,12 @@ private slots:
     void updateButtonStates();
 
 private:
-    bool canAdd(const QString &text) const;
+    void appendListItem(const CommandPreset &preset);
+    void applyPresetToItem(QListWidgetItem *item, const CommandPreset &preset) const;
+    CommandPreset presetFromItem(int row) const;
 
 private:
     QListWidget *m_listWidget;
-    QLineEdit *m_inputEdit;
     QPushButton *m_addButton;
     QPushButton *m_removeButton;
 };

--- a/SerialTool/src/views/texttr/commandeditdialog.cpp
+++ b/SerialTool/src/views/texttr/commandeditdialog.cpp
@@ -1,0 +1,81 @@
+#include "commandeditdialog.h"
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+
+CommandEditDialog::CommandEditDialog(QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(tr("Command Details"));
+    setModal(true);
+    resize(420, 320);
+
+    auto *mainLayout = new QVBoxLayout(this);
+
+    auto *nameLayout = new QHBoxLayout();
+    auto *nameLabel = new QLabel(tr("Name"), this);
+    nameLayout->addWidget(nameLabel);
+    m_nameEdit = new QLineEdit(this);
+    nameLayout->addWidget(m_nameEdit, 1);
+    mainLayout->addLayout(nameLayout);
+
+    auto *commandLabel = new QLabel(tr("Command"), this);
+    mainLayout->addWidget(commandLabel);
+    m_commandEdit = new QPlainTextEdit(this);
+    m_commandEdit->setTabChangesFocus(false);
+    mainLayout->addWidget(m_commandEdit, 1);
+
+    auto *noteLayout = new QHBoxLayout();
+    auto *noteLabel = new QLabel(tr("Note"), this);
+    noteLayout->addWidget(noteLabel);
+    m_noteEdit = new QLineEdit(this);
+    noteLayout->addWidget(m_noteEdit, 1);
+    mainLayout->addLayout(noteLayout);
+
+    m_buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+    mainLayout->addWidget(m_buttonBox);
+
+    connect(m_buttonBox, &QDialogButtonBox::accepted, this, &CommandEditDialog::accept);
+    connect(m_buttonBox, &QDialogButtonBox::rejected, this, &CommandEditDialog::reject);
+    connect(m_nameEdit, &QLineEdit::textChanged, this, &CommandEditDialog::updateButtonStates);
+    connect(m_commandEdit, &QPlainTextEdit::textChanged, this, &CommandEditDialog::updateButtonStates);
+
+    updateButtonStates();
+}
+
+void CommandEditDialog::setPreset(const CommandPreset &preset)
+{
+    m_nameEdit->setText(preset.name);
+    m_commandEdit->setPlainText(preset.command);
+    m_noteEdit->setText(preset.note);
+    updateButtonStates();
+}
+
+void CommandEditDialog::setCommandText(const QString &command)
+{
+    m_commandEdit->setPlainText(command);
+    updateButtonStates();
+}
+
+CommandPreset CommandEditDialog::preset() const
+{
+    CommandPreset preset;
+    preset.name = m_nameEdit->text().trimmed();
+    preset.command = m_commandEdit->toPlainText();
+    preset.note = m_noteEdit->text().trimmed();
+    return preset;
+}
+
+void CommandEditDialog::updateButtonStates()
+{
+    const bool hasCommand = !m_commandEdit->toPlainText().trimmed().isEmpty();
+    QPushButton *okButton = m_buttonBox->button(QDialogButtonBox::Ok);
+    if (okButton) {
+        okButton->setEnabled(hasCommand);
+    }
+}

--- a/SerialTool/src/views/texttr/commandeditdialog.h
+++ b/SerialTool/src/views/texttr/commandeditdialog.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "commandpreset.h"
+
+#include <QDialog>
+
+class QDialogButtonBox;
+class QLineEdit;
+class QPlainTextEdit;
+
+class CommandEditDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CommandEditDialog(QWidget *parent = nullptr);
+
+    void setPreset(const CommandPreset &preset);
+    void setCommandText(const QString &command);
+    CommandPreset preset() const;
+
+private slots:
+    void updateButtonStates();
+
+private:
+    QLineEdit *m_nameEdit;
+    QPlainTextEdit *m_commandEdit;
+    QLineEdit *m_noteEdit;
+    QDialogButtonBox *m_buttonBox;
+};

--- a/SerialTool/src/views/texttr/commandpreset.h
+++ b/SerialTool/src/views/texttr/commandpreset.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QString>
+
+struct CommandPreset
+{
+    QString name;
+    QString command;
+    QString note;
+};
+
+inline bool operator==(const CommandPreset &lhs, const CommandPreset &rhs)
+{
+    return lhs.name == rhs.name && lhs.command == rhs.command && lhs.note == rhs.note;
+}

--- a/SerialTool/src/views/texttr/texttrview.cpp
+++ b/SerialTool/src/views/texttr/texttrview.cpp
@@ -1,7 +1,9 @@
 #include "texttrview.h"
 #include "ui_texttrview.h"
 #include "commandconfigdialog.h"
+#include "commandeditdialog.h"
 #include <QCheckBox>
+#include <QColor>
 #include <QDateTime>
 #include <QFile>
 #include <QKeyEvent>
@@ -14,10 +16,12 @@
 #include <QStandardItem>
 #include <QStandardItemModel>
 #include <QTextCodec>
-#include <QTextDocument>
 #include <QTextCursor>
+#include <QTextDocument>
 #include <QTimer>
 #include <QToolButton>
+#include <QVariant>
+#include <algorithm>
 
 TextTRView::TextTRView(QWidget *parent) :
     AbstractView(parent),
@@ -192,12 +196,15 @@ void TextTRView::loadUserCommands(QSettings *config)
 {
     m_userCommands.clear();
     config->beginGroup("UserCommands");
-    int count = config->beginReadArray("Items");
+    const int count = config->beginReadArray("Items");
     for (int i = 0; i < count; ++i) {
         config->setArrayIndex(i);
-        const QString value = config->value("data").toString();
-        if (!value.isEmpty()) {
-            m_userCommands.append(value);
+        CommandPreset preset;
+        preset.name = config->value("name").toString();
+        preset.command = config->value("data").toString();
+        preset.note = config->value("note").toString();
+        if (!preset.command.isEmpty()) {
+            m_userCommands.append(preset);
         }
     }
     config->endArray();
@@ -210,7 +217,10 @@ void TextTRView::saveUserCommands(QSettings *config)
     config->beginWriteArray("Items");
     for (int i = 0; i < m_userCommands.size(); ++i) {
         config->setArrayIndex(i);
-        config->setValue("data", m_userCommands.at(i));
+        const CommandPreset &preset = m_userCommands.at(i);
+        config->setValue("name", preset.name);
+        config->setValue("data", preset.command);
+        config->setValue("note", preset.note);
     }
     config->endArray();
     config->endGroup();
@@ -233,8 +243,9 @@ void TextTRView::refreshCommandBox()
     }
     model->clear();
 
-    for (const QString &command : m_userCommands) {
-        auto *item = new QStandardItem(command);
+    for (const CommandPreset &preset : m_userCommands) {
+        auto *item = new QStandardItem(commandDisplayText(preset));
+        item->setData(preset.command, Qt::UserRole);
         model->appendRow(item);
     }
 
@@ -246,6 +257,7 @@ void TextTRView::refreshCommandBox()
 
     for (const QString &history : m_historyRecords) {
         auto *item = new QStandardItem(history);
+        item->setData(history, Qt::UserRole);
         model->appendRow(item);
     }
 
@@ -266,17 +278,24 @@ void TextTRView::rememberHistory(const QString &command)
     refreshCommandBox();
 }
 
-void TextTRView::appendReceivedEntry(const QString &text)
+void TextTRView::appendLogEntry(LogDirection direction, bool isHexMode, const QString &text)
 {
     if (text.isEmpty()) {
         return;
     }
-    QString entry = text;
-    if (!entry.endsWith('\n')) {
-        entry.append('\n');
+    QString entryText = text;
+    while (entryText.endsWith('\n') || entryText.endsWith('\r')) {
+        entryText.chop(1);
     }
-    m_receivedTexts.append(entry);
-    m_entryTimestamps.append(QDateTime::currentDateTime());
+    if (entryText.isEmpty()) {
+        return;
+    }
+    LogEntry entry;
+    entry.timestamp = QDateTime::currentDateTime();
+    entry.text = entryText;
+    entry.direction = direction;
+    entry.isHex = isHexMode;
+    m_logEntries.append(entry);
     rebuildReceiveView();
 }
 
@@ -289,31 +308,87 @@ void TextTRView::rebuildReceiveView()
     const bool atBottom = ui->textEditRx->verticalScrollBar()->value() ==
             ui->textEditRx->verticalScrollBar()->maximum();
 
-    QString buffer;
-    buffer.reserve(m_receivedTexts.size() * 32);
-    for (int i = 0; i < m_receivedTexts.size(); ++i) {
-        const QString &raw = m_receivedTexts.at(i);
-        if (!filter.isEmpty() && !raw.contains(filter, Qt::CaseInsensitive)) {
-            continue;
+    ui->textEditRx->clear();
+    QTextCursor cursor = ui->textEditRx->textCursor();
+    cursor.movePosition(QTextCursor::Start);
+
+    bool hasContent = false;
+    for (const LogEntry &entry : m_logEntries) {
+        const QString metadata = formatMetadata(entry);
+        const QString message = entry.text;
+        if (!filter.isEmpty()) {
+            const Qt::CaseSensitivity cs = Qt::CaseInsensitive;
+            if (!metadata.contains(filter, cs) && !message.contains(filter, cs)) {
+                continue;
+            }
         }
-        buffer.append(formatEntry(m_entryTimestamps.at(i), raw));
+
+        if (hasContent) {
+            cursor.insertBlock();
+        }
+        hasContent = true;
+
+        const QTextCharFormat format = formatForEntry(entry);
+        if (!metadata.isEmpty()) {
+            cursor.insertText(metadata, format);
+            cursor.insertBlock();
+        }
+
+        QString normalized = message;
+        normalized.replace(QStringLiteral("\r\n"), QStringLiteral("\n"));
+        normalized.replace('\r', '\n');
+        const QStringList lines = normalized.split('\n');
+        for (int i = 0; i < lines.size(); ++i) {
+            if (i > 0) {
+                cursor.insertBlock();
+            }
+            cursor.insertText(lines.at(i), format);
+        }
     }
 
-    ui->textEditRx->setPlainText(buffer);
+    ui->textEditRx->setTextCursor(cursor);
     if (atBottom) {
-        QTextCursor cursor = ui->textEditRx->textCursor();
-        cursor.movePosition(QTextCursor::End);
-        ui->textEditRx->setTextCursor(cursor);
+        QTextCursor endCursor = ui->textEditRx->textCursor();
+        endCursor.movePosition(QTextCursor::End);
+        ui->textEditRx->setTextCursor(endCursor);
         ui->textEditRx->verticalScrollBar()->setValue(ui->textEditRx->verticalScrollBar()->maximum());
     }
 }
 
-QString TextTRView::formatEntry(const QDateTime &timestamp, const QString &text) const
+QString TextTRView::formatMetadata(const LogEntry &entry) const
 {
-    if (!m_logWithTimestamp) {
-        return text;
+    const QString directionText = entry.direction == LogDirection::Receive
+            ? QStringLiteral("RECV")
+            : QStringLiteral("SEND");
+    const QString codecText = entry.isHex ? QStringLiteral("HEX") : QStringLiteral("ASCII");
+    if (m_logWithTimestamp) {
+        return QStringLiteral("[%1]# %2 %3")
+                .arg(entry.timestamp.toString(m_timeStampFormat), directionText, codecText);
     }
-    return QStringLiteral("[%1] %2").arg(timestamp.toString(m_timeStampFormat), text);
+    return QStringLiteral("# %1 %2").arg(directionText, codecText);
+}
+
+QTextCharFormat TextTRView::formatForEntry(const LogEntry &entry) const
+{
+    static const QColor kReceiveColor(QStringLiteral("#66bb6a"));
+    static const QColor kTransmitColor(QStringLiteral("#1976d2"));
+    QTextCharFormat format;
+    format.setForeground(entry.direction == LogDirection::Receive ? kReceiveColor : kTransmitColor);
+    return format;
+}
+
+QString TextTRView::commandDisplayText(const CommandPreset &preset) const
+{
+    if (!preset.name.isEmpty() && !preset.note.isEmpty()) {
+        return QStringLiteral("%1 — %2").arg(preset.name, preset.note);
+    }
+    if (!preset.name.isEmpty()) {
+        return preset.name;
+    }
+    if (!preset.note.isEmpty()) {
+        return QStringLiteral("%1 — %2").arg(preset.command, preset.note);
+    }
+    return preset.command;
 }
 
 void TextTRView::findInReceive(bool forward)
@@ -336,21 +411,21 @@ void TextTRView::findInReceive(bool forward)
 
 void TextTRView::receiveData(const QByteArray &array)
 {
-    QString string, pre;
-    if (ui->portReadAscii->isChecked()) {
-        if (m_hexCount > 0) {
-            pre = '\n';
-        }
-        m_hexCount = -1;
-        arrayToString(string, array);
-    } else {
+    if (array.isEmpty()) {
+        return;
+    }
+    QString string;
+    const bool hexMode = ui->portReadHex->isChecked();
+    if (hexMode) {
         if (m_hexCount == -1) {
             m_hexCount = 0;
-            pre = '\n';
         }
         arrayToHex(string, array, 16);
+    } else {
+        m_hexCount = -1;
+        arrayToString(string, array);
     }
-    appendReceivedEntry(pre + string);
+    appendLogEntry(LogDirection::Receive, hexMode, string);
 }
 
 void TextTRView::clear()
@@ -358,8 +433,7 @@ void TextTRView::clear()
     ui->textEditRx->clear();
     m_asciiBuf->clear();
     m_hexCount = 0;
-    m_receivedTexts.clear();
-    m_entryTimestamps.clear();
+    m_logEntries.clear();
     rebuildReceiveView();
 }
 
@@ -385,16 +459,20 @@ void TextTRView::setEnabled(bool enabled)
 void TextTRView::sendData()
 {
     QByteArray array;
+    const QString text = ui->textEditTx->toPlainText();
 
     if (ui->portWriteAscii->isChecked() == true) {
         if(m_codecName == "ASCII"){
-            array = ui->textEditTx->toPlainText().toLatin1();
+            array = text.toLatin1();
         }else{
             QTextCodec *code = QTextCodec::codecForName(m_codecName);
-            array = code->fromUnicode(ui->textEditTx->toPlainText());
+            array = code->fromUnicode(text);
         }
     } else {
-        array = QByteArray::fromHex(ui->textEditTx->toPlainText().toLatin1());
+        array = QByteArray::fromHex(text.toLatin1());
+    }
+    if (!text.isEmpty()) {
+        appendLogEntry(LogDirection::Transmit, ui->portWriteHex->isChecked(), text);
     }
     emit transmitData(array);
 }
@@ -451,9 +529,19 @@ void TextTRView::setTextCodec(const QString &name)
     }
 }
 
-void TextTRView::onHistoryBoxChanged(const QString &string)
+void TextTRView::onHistoryBoxChanged(const QString &)
 {
-    ui->textEditTx->setPlainText(string);
+    const int index = ui->historyBox->currentIndex();
+    if (index < 0) {
+        return;
+    }
+    const QVariant data = ui->historyBox->itemData(index, Qt::UserRole);
+    const QString command = data.toString();
+    if (!command.isEmpty()) {
+        ui->textEditTx->setPlainText(command);
+    } else {
+        ui->textEditTx->setPlainText(ui->historyBox->itemText(index));
+    }
 }
 
 void TextTRView::onFilterTextChanged(const QString &)
@@ -479,14 +567,34 @@ void TextTRView::onLogTimestampToggled(bool enabled)
 
 void TextTRView::onSaveCommandClicked()
 {
-    const QString command = ui->textEditTx->toPlainText().trimmed();
-    if (command.isEmpty()) {
+    CommandEditDialog dialog(this);
+    dialog.setCommandText(ui->textEditTx->toPlainText());
+    if (dialog.exec() != QDialog::Accepted) {
         return;
     }
-    if (!m_userCommands.contains(command)) {
-        m_userCommands.prepend(command);
-        refreshCommandBox();
+    CommandPreset preset = dialog.preset();
+    preset.command = preset.command.trimmed();
+    if (preset.command.isEmpty()) {
+        return;
     }
+
+    auto it = std::find_if(m_userCommands.begin(), m_userCommands.end(), [&](const CommandPreset &existing) {
+        if (!preset.name.isEmpty() && !existing.name.isEmpty()) {
+            return existing.name.compare(preset.name, Qt::CaseInsensitive) == 0;
+        }
+        return existing.command == preset.command;
+    });
+    if (it != m_userCommands.end()) {
+        const int index = int(it - m_userCommands.begin());
+        m_userCommands[index] = preset;
+        if (index > 0) {
+            m_userCommands.remove(index);
+            m_userCommands.prepend(preset);
+        }
+    } else {
+        m_userCommands.prepend(preset);
+    }
+    refreshCommandBox();
 }
 
 void TextTRView::onManageCommandsClicked()

--- a/SerialTool/src/views/texttr/texttrview.h
+++ b/SerialTool/src/views/texttr/texttrview.h
@@ -1,16 +1,21 @@
 #ifndef TEXTTRVIEW_H
 #define TEXTTRVIEW_H
 
+#include "commandpreset.h"
 #include "../abstractview.h"
 
 #include <QByteArray>
 #include <QDateTime>
 #include <QStringList>
+#include <QTextCharFormat>
 #include <QVector>
 
 namespace Ui {
 class TextTRView;
 }
+
+class QKeyEvent;
+class QTimer;
 
 class TextTRView : public AbstractView
 {
@@ -35,6 +40,18 @@ public:
     void saveFile(const QString &fileName, const QString &filter);
 
 private:
+    enum class LogDirection {
+        Receive,
+        Transmit
+    };
+
+    struct LogEntry {
+        QDateTime timestamp;
+        QString text;
+        LogDirection direction;
+        bool isHex = false;
+    };
+
     void setFontFamily(QString fonts, int size, QString style);
     void setHighlight(const QString &language);
     void setTextCodec(const QString &name);
@@ -44,9 +61,11 @@ private:
     void setIndentationGuides(bool enable);
     void saveText(const QString &fname);
 
-    void appendReceivedEntry(const QString &text);
+    void appendLogEntry(LogDirection direction, bool isHexMode, const QString &text);
     void rebuildReceiveView();
-    QString formatEntry(const QDateTime &timestamp, const QString &text) const;
+    QString formatMetadata(const LogEntry &entry) const;
+    QTextCharFormat formatForEntry(const LogEntry &entry) const;
+    QString commandDisplayText(const CommandPreset &preset) const;
     void refreshCommandBox();
     void loadUserCommands(QSettings *config);
     void saveUserCommands(QSettings *config);
@@ -95,10 +114,9 @@ private:
     QByteArray m_codecName;
     bool m_logWithTimestamp = false;
     QString m_timeStampFormat;
-    QVector<QDateTime> m_entryTimestamps;
-    QStringList m_receivedTexts;
+    QVector<LogEntry> m_logEntries;
     QStringList m_historyRecords;
-    QStringList m_userCommands;
+    QVector<CommandPreset> m_userCommands;
 };
 
 #endif // TEXTTRVIEW_H


### PR DESCRIPTION
## Summary
- rework the text transfer log to show metadata and message on separate lines with color-coded TX/RX entries
- introduce structured logging to preserve timestamp, direction, and encoding information in the receive pane
- add a dialog for naming and annotating saved commands and persist the richer presets in the configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ec92fbb39883239c183910dc820952